### PR TITLE
[#50] 촬영 기기에서 촬영 완료 시 보여줄 UI를 구현한다.

### DIFF
--- a/mirroringBooth/mirroringBooth/Device/Camera/StreamingCompletionView.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/StreamingCompletionView.swift
@@ -1,0 +1,35 @@
+//
+//  StreamingCompletionView.swift
+//  mirroringBooth
+//
+//  Created by 이상유 on 2026-01-13.
+//
+
+import SwiftUI
+
+struct StreamingCompletionView: View {
+    var body: some View {
+        ZStack {
+            Color.background
+                .ignoresSafeArea()
+
+            VStack(spacing: 10) {
+                // TODO: #26 병합 후 HomeButton 추가
+                Image(systemName: "photo.badge.checkmark")
+                    .font(.largeTitle.bold())
+                    .foregroundStyle(Color.main)
+                VStack(spacing: 5) {
+                    Text("촬영이 완료되었습니다!")
+                        .font(.title2.bold())
+                    Text("미러링 기기에서 편집을 진행해주세요.")
+                        .font(.subheadline.bold())
+                        .opacity(0.7)
+                }
+                Text("편집이 완료된 사진을 이 디바이스에 저장하고 싶다면\n이 화면에서 대기해주세요.")
+                    .font(.footnote)
+                    .opacity(0.7)
+                    .multilineTextAlignment(.center)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 🔗 연관된 이슈

- closed #50

## 📝 작업 내용

### 📌 요약

촬영 기기에서 촬영 완료 후 보여줄 UI를 구현했습니다.

### 🔍 상세

**미러링 기기에서 편집을 진행해달라는 안내**를 포함했습니다.

더해서 편집 완료 시 결과 화면을 촬영 기기에서도 보여줄 예정이기에 **저장을 원한다면 대기해달라는 문구를 포함**했습니다.  
(연결이 끊기면 결과 화면을 보여주지 못하기 때문에 해당 문구를 포함시켰습니다.)

## 💬 리뷰 노트

### 안내 문구

더 나은 안내 문구가 떠오르신다면 피드백 부탁드립니다!

제 기준에는 친철해보이지만 다르게 느낄 수도 있겠다 싶어 요청드려봅니다.

### 홈 버튼
[이전 PR](https://github.com/boostcampwm2025/iOS03-dolAwang/pull/75)에서 홈 버튼을 구현하고 컴포넌트로 분리해뒀습니다.

같은 내용의 커밋이 생길 것을 우려해 현재 PR에는 해당 내용을 포함시키지 않았습니다.

주석으로 처리해둔 상황이고, 이전 PR이 병합된다면 바로 업데이트 하거나, 이전 화면과 연결하는 작업을 진행할 때 포함시키도록 하겠습니다.

## 📸 영상 / 이미지
### iPhone Pro Max
<img width="363" height="755" alt="스크린샷 2026-01-13 15 42 20" src="https://github.com/user-attachments/assets/cc578079-7842-48c2-805e-0918d36f6935" />

### iPhone SE
<img width="363" height="668" alt="스크린샷 2026-01-13 15 43 05" src="https://github.com/user-attachments/assets/badae185-510a-4cac-be6a-3b206c85dcd9" />
