### PR TITLE
[fix/#81] 리모트 기기가 자동으로 연결되는 버그를 수정한다.

### DIFF
--- a/mirroringBooth/mirroringBooth/Device/Camera/Connection/Browser.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Connection/Browser.swift
@@ -112,7 +112,8 @@ final class Browser: NSObject {
         switch useType {
         case .mirroring:
             targetMirroringDeviceID = deviceID
-            targetSession = mirroringSession
+            // 커맨드 세션에 대해 먼저 연결을 요청합니다.
+            targetSession = mirroringCommandSession
         case .remote:
             targetRemoteDeviceID = deviceID
             targetSession = remoteSession
@@ -121,7 +122,7 @@ final class Browser: NSObject {
         browser.invitePeer(
             peer,
             to: targetSession,
-            withContext: SessionType.streaming.rawValue.data(using: .utf8),
+            withContext: SessionType.command.rawValue.data(using: .utf8),
             timeout: 10
         )
         logger.info("연결 요청 전송: \(deviceID) (\(useType == .mirroring ? "미러링" : "리모트"))")
@@ -235,7 +236,20 @@ extension Browser: MCSessionDelegate {
         didChange state: MCSessionState
     ) {
         let sessionTypeLabel = getSessionTypeLabel(for: session)
+
         let newState = logAndConvertState(state, for: peerID.displayName, sessionType: sessionTypeLabel)
+
+        // 미러링 세션이 연결되면 명령 세션을 초대합니다.
+        if sessionTypeLabel == "미러링 명령", newState == .connected {
+            logger.info("미러링 커맨드 세션 연결 완료, 미러링 세션 초대 시작")
+            browser.invitePeer(
+                peerID,
+                to: mirroringSession,
+                withContext: SessionType.streaming.rawValue.data(using: .utf8),
+                timeout: 10
+            )
+            return
+        }
 
         let deviceType = discoveredPeers[peerID.displayName]?.type ?? .unknown
         discoveredPeers[peerID.displayName] = (peer: peerID, type: deviceType)
@@ -295,17 +309,6 @@ extension Browser: MCSessionDelegate {
         switch state {
         case .connected:
             onDeviceConnected?(device)
-
-            // 미러링 세션이 연결되면 명령 세션을 초대합니다.
-            if isMirroringTarget {
-                logger.info("미러링 세션 연결 완료, command 세션 초대 시작")
-                browser.invitePeer(
-                    peerID,
-                    to: mirroringCommandSession,
-                    withContext: SessionType.command.rawValue.data(using: .utf8),
-                    timeout: 10
-                )
-            }
 
         case .notConnected:
             onDeviceConnectionFailed?()


### PR DESCRIPTION
## 🔗 연관된 이슈
- closed #81

## 문제 상황
미러링 기기를 연결하면 자동으로 리모트 기기까지 연결됩니다.(선택한 미러링 기기가 리모트 기기로 간주)

## 📝 작업 내용

### 📌 요약
- mirroring 기기와 연결시 커맨드세션을 먼저 연결하고 스트리밍 세션을 연결하게 변경합니다.

## 💬 리뷰 노트
오류의 원인은 Browser에서 sessionDelegate가 불렸을 때(didChange state) 미러링 세션이 연결된 경우가 BrowsingStore에서의 상태 전환을 촉발하는 것이었습니다. 
- 미러링 세션이 연결됨
- 스토어가 리모트 기기를 찾음
- 뒤늦게 커맨드 세션이 자동 연결됨
- onDeviceFound가 호출되어 리모트 기기로 간주됨 

## 📸 영상 / 이미지 (
### Before
https://github.com/user-attachments/assets/e7fa9273-bde4-44ef-88b3-febfeb2050d9

Optional)

### After

https://github.com/user-attachments/assets/54910190-9892-415b-bd5a-d7e18402a5f7



