### PR TITLE
[fix/#44] mac이 iPad로 인식되는 문제를 해결한다.

### DIFF
--- a/mirroringBooth/mirroringBooth/Core/UIDevice+.swift
+++ b/mirroringBooth/mirroringBooth/Core/UIDevice+.swift
@@ -1,0 +1,18 @@
+//
+//  UIDevice+.swift
+//  mirroringBooth
+//
+//  Created by Liam on 1/15/26.
+//
+
+import UIKit
+
+extension UIDevice {
+    var deviceType: String {
+        // build는 iOS이지만 실행 기기가 Mac인지 확인
+        if ProcessInfo.processInfo.isiOSAppOnMac {
+            return "Mac"
+        }
+        return UIDevice.current.name
+    }
+}

--- a/mirroringBooth/mirroringBooth/Device/Camera/Connection/Browser.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Connection/Browser.swift
@@ -61,7 +61,7 @@ final class Browser: NSObject {
 
     init(serviceType: String = "mirroringbooth") {
         self.serviceType = serviceType
-        self.myDeviceName = PeerNameGenerator.makeDisplayName(isRandom: false, with: UIDevice.current.name)
+        self.myDeviceName = PeerNameGenerator.makeDisplayName(isRandom: false, with: UIDevice.current.deviceType)
         self.peerID = MCPeerID(displayName: myDeviceName)
         self.mirroringSession = MCSession(
             peer: peerID,

--- a/mirroringBooth/mirroringBooth/Device/Common/Advertiser/Advertiser.swift
+++ b/mirroringBooth/mirroringBooth/Device/Common/Advertiser/Advertiser.swift
@@ -48,7 +48,7 @@ final class Advertiser: NSObject {
 
     init(serviceType: String = "mirroringbooth", photoCacheManager: PhotoCacheManager) {
         self.serviceType = serviceType
-        self.myDeviceName = PeerNameGenerator.makeDisplayName(isRandom: true, with: UIDevice.current.name)
+        self.myDeviceName = PeerNameGenerator.makeDisplayName(isRandom: true, with: UIDevice.current.deviceType)
         self.peerID = MCPeerID(displayName: myDeviceName)
         self.session = MCSession(
             peer: peerID,
@@ -64,7 +64,13 @@ final class Advertiser: NSObject {
         let myDeviceType: String = {
         #if os(iOS)
             if UIDevice.current.userInterfaceIdiom == .phone { return "iPhone" }
-            if UIDevice.current.userInterfaceIdiom == .pad { return "iPad" }
+            if UIDevice.current.userInterfaceIdiom == .pad {
+                // build는 iOS이지만 실행 기기가 Mac인지 확인
+                if ProcessInfo.processInfo.isiOSAppOnMac {
+                    return "Mac"
+                }
+                return "iPad"
+            }
             return "iOS"
         #elseif os(macOS)
             return "Mac"


### PR DESCRIPTION
## 🔗 연관된 이슈
- closed #44

## 📝 작업 내용

### 📌 요약
- 기기명 Mac이 정상적으로 표시됩니다.

### 🔍 상세
ProcessInfo.processInfo.isiOSAppOnMac 을 이용하여 확인합니다.
UIDevice extension을 추가하여 필요시 UIDvice.current.deviceType이 current.name을 대체합니다.

## 📸 영상 / 이미지 (Optional)
<img width="250" height="600" alt="Simulator Screenshot - iPhone 17 Pro - 2026-01-15 at 12 47 28" src="https://github.com/user-attachments/assets/34703cbd-d41f-4c9f-8f9a-b4d91d204fe2" />
