### PR TITLE
[#127] 커스텀 배경 색상 지정 기능이 전체 화면에 적용되지 않아 생긴 UI의 어색함을 해결한다.

### DIFF
--- a/mirroringBooth/mirroringBooth/Device/Common/View+Background.swift
+++ b/mirroringBooth/mirroringBooth/Device/Common/View+Background.swift
@@ -9,9 +9,8 @@ import SwiftUI
 
 extension View {
     func backgroundStyle() -> some View {
-        self.background(
-            Color.background
-                .ignoresSafeArea()
-        )
+        self
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(Color.background, ignoresSafeAreaEdges: .all)
     }
 }


### PR DESCRIPTION
## 🔗 연관된 이슈

- closed #127

## 📝 작업 내용

### 📌 요약

- 배경색 modifier `backgroundStyle()`이 잘 적용되지 않았던 문제를 해결했습니다.

### 🔍 상세

- 기존에는 `View`의 `background`에 배경색을 적용하면서 .`ignoresSafeArea()`만 설정하고 있어 전체 화면을 덮지 않았습니다.
- `maxWidth`와 `maxHeight`를 `.infinity`로 설정하면서 배경색이 전체 화면을 덮도록 수정했습니다.

## 📸 영상 / 이미지
| 수정 이전 (LIGHT) | 수정 이후 (LIGHT) |  
| --- | --- |  
| <img width="499" height="644" alt="before-light" src="https://github.com/user-attachments/assets/25dcb6c5-d121-4b25-8298-a840ad5be9fe" /> | <img width="499" height="644" alt="after-light" src="https://github.com/user-attachments/assets/ddaef313-9698-4484-acf4-51345e9e903c" /> |  
| 수정 이전 (DARK) | 수정 이후 (DARK) |  
| <img width="499" height="644" alt="before-dark" src="https://github.com/user-attachments/assets/5bfaa0ab-5c7e-4827-98f6-339c1d8c4d29" /> | <img width="499" height="644" alt="after-dark" src="https://github.com/user-attachments/assets/f68e59f2-47b5-414f-8852-39e33b42ee1b" /> |  