### PR TITLE
[#135] 애플워치 외의 리모트 기기에서 촬영 요청을 했을 때 촬영 횟수가 증가되지 않는 현상을 해결한다

### DIFF
--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/Browser.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/Browser.swift
@@ -139,6 +139,12 @@ final class Browser: NSObject {
         logger.info("연결 요청 전송: \(deviceID) (\(useType == .mirroring ? "미러링" : "리모트"))")
     }
 
+    /// 카메라 캡쳐 액션을 실행합니다.
+    func capturePhoto() {
+        self.onCaptureCommand?()
+        self.sendCommand(.onUpdateCaptureCount)
+    }
+
     /// 미러링 세션에 연결된 피어에게 스트림 데이터를 전송합니다.
     func sendStreamData(_ data: Data) {
         guard let mirroringSession else { return }
@@ -391,7 +397,7 @@ extension Browser: MCSessionDelegate {
             switch type {
             case .capturePhoto:
                 DispatchQueue.main.async {
-                    self.onCaptureCommand?()
+                    self.capturePhoto()
                 }
             case .startTransfer:
                 DispatchQueue.main.async {
@@ -469,13 +475,5 @@ extension Browser: MCNearbyServiceBrowserDelegate {
         DispatchQueue.main.async {
             self.onDeviceLost?(device)
         }
-    }
-}
-
-// MARK: - WatchConnectionManager
-extension Browser {
-    func capturePhoto() {
-        self.onCaptureCommand?()
-        self.sendCommand(.onUpdateCaptureCount)
     }
 }


### PR DESCRIPTION
## 🔗 연관된 이슈
- closed #135

## 📝 작업 내용

### 📌🔍 요약 && 상세
- 기존의 WatchConnectionManager 용으로 호출되는 메서드를 직접 호출하도록 수정하였습니다
- 그 외 코드를 건드리지 않았으므로 애플워치에서도 정상적인 액션을 기대할 수 있습니다

## 💬 리뷰 노트
의외로 간단했습니다...

## 📸 영상 / 이미지 (Optional)

https://github.com/user-attachments/assets/7cc9e03a-b050-4533-a4fe-7d51fe7c1378