### PR TITLE
[fix/#137] BrowsingView의 건너뛰기 버튼을 의도에 맞게 수정한다.

### DIFF
--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowsingView.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowsingView.swift
@@ -106,7 +106,7 @@ struct BrowsingView: View {
                                 ? Color(store.state.currentTarget.color)
                                 : Color("mirroringColor").opacity(0.6)
                             )
-                            .cornerRadius(12)
+                            .clipShape(RoundedRectangle(cornerRadius: 12))
                     }
                 }
             }


### PR DESCRIPTION
## 🔗 연관된 이슈
> 이슈 번호를 입력해주세요. (예: #12)
> 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요.
- closed #137 

## 📝 작업 내용
- BrowsingView의 배경 애니메이션과 하단 버튼의 UI를 개선했습니다.

### 📌 요약
- 저번 마스터클래스에서 배경 애니메이션이 중앙 배경을 차지해 하단 버튼의 의도가 가려진다는 피드백을 받았습니다.
- 또한 기존 버튼이 `단일 회색 텍스트`로 이뤄져있어 버튼의 가시성이 뚜렷하지 않으며 `건너뛰기`라는 워딩이 헷갈리게 다가온다는 피드백도 있었습니다.
- 버튼 텍스트 `건너뛰기`를 `리모트 기기 없이 시작`으로 변경하여 의도가 드러나도록 개선했습니다.

## 📸 영상 / 이미지 (Optional)

### 미러링 기기만 선택한 경우

| 라이트 모드 | 다크 모드 |
|-----------|---------|
| <img width="500" alt="IMG_2939" src="https://github.com/user-attachments/assets/551c1f9a-e004-48cb-9e96-e94cd02520ab" /> | <img width="500" alt="IMG_2940" src="https://github.com/user-attachments/assets/c783abb9-f8d8-4492-a442-581b08e28181" /> |

### 모든 기기를 선택한 경우

| 라이트 모드 | 다크 모드 |
|-----------|---------|
| <img width="500" alt="IMG_2941" src="https://github.com/user-attachments/assets/612535af-04dc-4506-968a-6c788322afbb" /> | <img width="500" alt="IMG_2942" src="https://github.com/user-attachments/assets/481b3e86-3821-4e34-8ae5-933f23b79781" /> |
