### PR TITLE
[Feat/#145] 애플워치가 아닌 리모트 기기의 내비게이션을 개선한다.

### DIFF
--- a/mirroringBooth/mirroringBooth/App/RootView.swift
+++ b/mirroringBooth/mirroringBooth/App/RootView.swift
@@ -65,8 +65,8 @@ struct RootView: View {
                 }
                 .navigationDestination(for: RemoteRoute.self) { viewType in
                     switch viewType {
-                    case .connection(let advertiser):
-                        RemoteConnectionView(advertiser: advertiser)
+                    case .connected(let advertiser):
+                        RemoteConnectedView(advertiser: advertiser)
                             .environment(router)
                     case .remoteCapture(let advertiser):
                         RemoteCaptureView(advertiser: advertiser)

--- a/mirroringBooth/mirroringBooth/Core/Router.swift
+++ b/mirroringBooth/mirroringBooth/Core/Router.swift
@@ -45,7 +45,7 @@ enum MirroringRoute: Hashable {
 }
 
 enum RemoteRoute: Hashable {
-    case connection(Advertiser)
+    case connected(Advertiser)
     case remoteCapture(Advertiser)
     case completion
 }

--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/Browser.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/Browser.swift
@@ -23,7 +23,7 @@ final class Browser: NSObject {
     enum RemoteDeviceCommand: String {
         case navigateToRemoteCapture
         case navigateToRemoteComplete
-        case navigateToRemoteConnection
+        case navigateToRemoteConnected
         case navigateToHome
     }
 

--- a/mirroringBooth/mirroringBooth/Device/Camera/ConnectionCheckView.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/ConnectionCheckView.swift
@@ -75,7 +75,7 @@ struct ConnectionCheckView: View {
                         ? .navigateToSelectModeWithoutRemote
                         : .navigateToSelectModeWithRemote
                     )
-                    browser.sendRemoteCommand(.navigateToRemoteConnection)
+                    browser.sendRemoteCommand(.navigateToRemoteConnected)
                     shouldNavigateToCompletion = false
                 } label: {
                     Text("촬영 준비하기")

--- a/mirroringBooth/mirroringBooth/Device/Remote/RemoteConnectedView.swift
+++ b/mirroringBooth/mirroringBooth/Device/Remote/RemoteConnectedView.swift
@@ -1,5 +1,5 @@
 //
-//  RemoteConnectionView.swift
+//  RemoteConnectedView.swift
 //  mirroringBooth
 //
 //  Created by 윤대현 on 1/20/26.
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct RemoteConnectionView: View {
+struct RemoteConnectedView: View {
     @Environment(Router.self) var router: Router
     let advertiser: Advertiser
 

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Advertiser.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Advertiser.swift
@@ -30,7 +30,7 @@ final class Advertiser: NSObject {
     var navigateToSelectModeCommandCallBack: ((_ isRemoteEnable: Bool) -> Void)?
 
     /// 촬영 대기 화면 이동 콜백 (리모트 기기)
-    var navigateToRemoteConnectionCallBack: (() -> Void)?
+    var navigateToRemoteConnectedCallBack: (() -> Void)?
 
     /// 촬영 화면 이동 콜백 (리모트 기기)
     var navigateToRemoteCaptureCallBack: (() -> Void)?
@@ -188,10 +188,10 @@ final class Advertiser: NSObject {
 
     private func handleRemoteDeviceCommand(_ remoteDeviceCommand: Browser.RemoteDeviceCommand) {
         switch remoteDeviceCommand {
-        case .navigateToRemoteConnection:
-            guard let navigateToRemoteConnectionCallBack else { return }
+        case .navigateToRemoteConnected:
+            guard let navigateToRemoteConnectedCallBack else { return }
             DispatchQueue.main.async {
-                navigateToRemoteConnectionCallBack()
+                navigateToRemoteConnectedCallBack()
             }
         case .navigateToRemoteCapture:
             guard let navigateToRemoteCaptureCallBack else { return }

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertiserHomeStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertiserHomeStore.swift
@@ -40,7 +40,7 @@ final class AdvertiserHomeStore: StoreProtocol {
             self?.reduce(.setIsConnecting(true, type: .mirroring))
         }
 
-        advertiser.navigateToRemoteConnectionCallBack = { [weak self] in
+        advertiser.navigateToRemoteConnectedCallBack = { [weak self] in
             self?.reduce(.setIsConnecting(true, type: .remote))
         }
 

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertiserHomeView.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertiserHomeView.swift
@@ -69,7 +69,7 @@ struct AdvertiserHomeView: View {
                         )
                     )
                 case .remote:
-                    router.push(to: RemoteRoute.connection(store.advertiser))
+                    router.push(to: RemoteRoute.connected(store.advertiser))
                 }
             }
         }


### PR DESCRIPTION
## 🔗 연관된 이슈
- closed #145

## 📝 작업 내용

### 📌 요약
- 애플워치가 아닌 리모트 기기 연결 성공 후, 즉시 `RemoteCaptureView`로 이동하지 않고 `RemoteConnectionView`(대기 화면)로 이동하도록 흐름을 개선했습니다.
- 미러링 기기에서 촬영 방식(리모트/타이머)을 선택한 결과에 따라 리모트 기기가 촬영 화면으로 이동하거나 홈으로 복귀하도록 명령/콜백 흐름을 연결했습니다.

### 🔍 상세
- `RemoteConnectionView` 추가
  - 연결 완료 상태 및 “미러링 기기에서 촬영 방식 선택 대기”를 안내하는 정보 전달용 화면을 구현했습니다.
  - `onAppear`와 `onDisappear`에서 `Advertiser` 콜백을 등록 및 해제하여 생명주기를 관리합니다.
- 리모트 기기 명령 분리 및 전송 로직 정리
  - `Browser.RemoteDeviceCommand`를 도입하고, 리모트 기기 전용 `sendRemoteCommand`로 명령 전송을 분리했습니다.
  - `navigateToRemoteConnection / navigateToRemoteCapture / navigateToHome` 명령을 통해 리모트 기기 UI 전환을 제어합니다.
- 플로우 변경
  - 촬영 기기 `ConnectionCheckView`에서 “촬영 준비하기” 클릭 시 아래와 같은 플로우를 진행합니다.
    - 미러링 기기: 모드 선택 화면으로 이동
    - 리모트 기기: `RemoteConnectionView`로 이동
  - 미러링 기기 `ModeSelectionView`에서 모드 선택 시 아래와 같은 플로우를 진행합니다.
    - 리모트 모드 선택: 리모트 기기를 `RemoteCaptureView`로 이동
    - 타이머 모드 선택: 리모트 기기를 AdvertiserHomeView로 복귀

## 💬 리뷰 노트
- **RemoteConnectionView의 역할/목적**
  - 리모트 기기 입장에서 “연결은 성공했으며 이제 미러링 기기가 촬영 방식을 결정하는 동안 대기 중”임을 명확히 전달하기 위한 대기/정보 전달용 화면입니다.
- Store를 사용하지 않은 이유에 대해서
  - 해당 뷰는 복잡한 상태 전이가 없고(`showCheckmark` 등 단순 로컬 UI 상태만 존재) 비즈니스 로직은 `Advertiser`의 콜백 기반으로 이미 구성되어 있어 Store로 분리하는 것이 현재 요구사항 대비 과한 추상화라고 판단했습니다!

## 📸 영상 / 이미지 (Optional)

### 리모트 기기 선택 후 리모트 모드를 선택했을 때

https://github.com/user-attachments/assets/bf7b4577-06a8-4fd1-9abc-e6aa2b61f7ac

### 리모트 기기 선택 후 타이머 모드를 선택했을 때
https://github.com/user-attachments/assets/63d79fff-e9a0-4b55-ab64-ddccafb559cc

