### PR TITLE
[Fix/#159] 타이머 모드에서 사진은 1번 찍히지만 카운트는 2씩 증가하는 버그를 해결한다.

### DIFF
--- a/mirroringBooth/mirroringBooth/Device/Mirroring/Streaming/StreamingStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Mirroring/Streaming/StreamingStore.swift
@@ -218,9 +218,9 @@ extension StreamingStore {
                 capturePhoto()
 
                 // 10장 촬영 완료 시
-                let nextCaptureCount = state.capturePhotoCount + 1
+                let currentCaptureCount = state.capturePhotoCount + 1
 
-                if nextCaptureCount >= state.totalCaptureCount {
+                if currentCaptureCount >= state.totalCaptureCount {
                     stopTimer()
                 } else {
                     results.append(.shootingCountdownUpdated(8))


### PR DESCRIPTION
## 🔗 연관된 이슈
- closed #159 

## 📝 작업 내용

### 📌 요약
타이머 모드에서 촬영 카운트가 2개씩 증가하는 버그를 수정했습니다.  
*(리모트 모드는 정상 작동합니다.)*

### 🔍 상세

#### 문제 발생 상황

https://github.com/user-attachments/assets/f5e0684d-6fd0-4de7-b54c-ff24933dddcb

영상 하단 로그를 보시면 `촬영 명령 전송: capturePhoto`는 1회씩 출력되고 있지만 촬영 카운트는 2개씩 증가하는 현상이 발생하고 있었습니다.  

원인은 타이머 모드의 `사진 촬영 카운트를 증가시키는 코드`가 중복 되어있었습니다.

우선, `StreamingStore`의 handleTick() 내부에서 촬영 카운트를 직접 증가시키는 코드가 1개 존재합니다.

```swift
// handleTick() 내부
capturePhoto()
let firstCount = state.capturePhotoCount + 1
results.append(.capturePhotoCountUpdated(firstCount))  //💡 해당 지점에서 1회 증가합니다.
```

그 후 또 다시 `원격에서 명령을 받아 다시 촬영 카운트를 증가`시키고 있었습니다. (Browser -> Advertiser -> StreamingStore)

```swift
// Browser의 capturePhoto()
self.onCaptureCommand?() // 실제 촬영 호출
self.sendCommand(.onUpdateCaptureCount) // Advertiser로 촬영 카운트 증가 명령을 전송합니다.

// StreamingStore의 action
case .capturePhotoCount:
      let newCount = min(state.totalCaptureCount, state.capturePhotoCount + 1)
      result.append(.capturePhotoCountUpdated(newCount)) // 💡 해당 지점에서 또 1회 증가합니다.
```

따라서 SSOT를 지키기 위해 `로컬에서 카운트를 증가시키는 코드`는 전부 제거하고 오직 `Browser`가 촬영 카운트를 증가시키는 방향으로 통일했습니다.

🧐 리모트 모드에서는 왜 발생하지 않았지?
- 리모트 모드는 타이머 로직 handleTick()을 거치지 않으며 Browser의 capturePhoto()만 호출되는 구조이기 때문에 정상적으로 동작하고 있었습니다.

## 📸 영상 / 이미지 (Optional)

### 성공 화면
> 타이머 모드, 리모트 모드 모두 정상 작동함을 확인했습니다.

https://github.com/user-attachments/assets/9a8578d8-8dec-40b6-8b52-d854a5a13455
