### PR TITLE
[fix/#182] 미러링/리모트 기기 선택 UI의 직관성을 개선한다.

### DIFF
--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/Component/DeviceRow.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/Component/DeviceRow.swift
@@ -47,6 +47,7 @@ struct DeviceRow: View {
 
             VStack(alignment: .leading) {
                 Text(device.id)
+                    .multilineTextAlignment(.leading)
                     .font(.headline.bold())
                 Text(device.type.rawValue)
                     .font(.footnote)


### PR DESCRIPTION
## 🔗 연관된 이슈
- closed #182

## 📝 작업 내용

### 📌 요약
BrowsingView의 DeviceRow 선택 UI를 변경했습니다.

### 🔍 상세
- 기기 선택 시 좌측 아이콘 색상을 해당 타겟 색상으로 변경하도록 수정했습니다.
- 우측에 체크마크를 표시하는 아이디어는 실제로 해보았지만 상당히.. 이상해보여서 제외했습니다..
- 선택된 기기에 타겟 색상 테두리 또한 추가했으며 SF Symbols 아이콘 크기 차이로 인한 정렬 이슈 해결했습니다.
   - 좌우 심볼 모두 32의 고정 프레임을 적용했습니다.
   - 또한 HStack에 spacing 또한 16정도로 변경하여 일관된 간격을 유지하도록 진행했습니다.

## 💬 리뷰 노트
- 사용자 피드백 : `미러링 기기 선택 후 리모트 단계로 넘어갔을 때, 미러링 기기가 제대로 선택되었는지 직관적으로 알기 어려웠어요`
- 진행하고자 했던 UI 개선 방향은 다음과 같았습니다.
   - 1. 미러링/리모트 대표 아이콘 변경 
   - 2. 좌측 아이콘 색상 변경
   - 3. 테두리 색상 추가
   - 4. 배경 색상 채우기

이 중 b번과 c번의 조합이 `이 기기가 활성화됨`을 가장 직관적으로 표현하며 우측 타겟 아이콘은 유지함으로써 `미러링`과 `리모트 역할`의 구분을 충분히 수행할 것이라고 판단했습니다.

또한 테두리 색상을 전체 Row에 감싸 `선택 완료됨`을 시각적으로 강조하고 싶었습니다.

기존 투명도 처리 아이디어는 자칫 `비활성화 된건가..?` 하는 잘못된 피드백이 제공될 수 있을 것 같으며, 배경 색상 채우기 또한 배경의 애니메이션과 시각적 충돌이 우려되어 제외했습니다.

### 📷 이미지

#### 기기 선택 전

| 라이트모드 | 다크모드 |
|-----------|---------|
| <img width="419" height="845" alt="라이트모드" src="https://github.com/user-attachments/assets/b6e0eb85-128e-4797-b674-6357766c4bd5" /> | <img width="427" height="844" alt="다크모드" src="https://github.com/user-attachments/assets/bafee8e5-67a0-48cb-9746-5bdda8a2f7f8" /> |

#### 기기 선택 후

| 라이트모드 | 다크모드 |
|-----------|---------|
| <img width="419" height="841" alt="라이트모드" src="https://github.com/user-attachments/assets/5bd4f1c2-fe79-44d5-8034-31f9711308f5" /> | <img width="415" height="842" alt="다크모드" src="https://github.com/user-attachments/assets/bded53d7-c270-4a74-9f22-604a3e35048e" /> |