### PR TITLE
[Feat/#188] 사진을 선택할 때 레이아웃 변경 시 선택 개수를 보정한다.

### DIFF
--- a/mirroringBooth/mirroringBooth/Device/Mirroring/PhotoComposition/PhotoCompositionStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Mirroring/PhotoComposition/PhotoCompositionStore.swift
@@ -121,11 +121,11 @@ final class PhotoCompositionStore: StoreProtocol {
                     }
                 }
 
-                let removeCount = copyState.selectedPhotos.count - newCapacity
-                if removeCount > 0 {
-                    copyState.selectedPhotos.removeLast(removeCount)
-                }
-                copyState.currentSelectionCount = newCapacity
+                copyState.selectedPhotos = copyState.photos
+                    .filter { $0.selectNumber != nil }
+                    .sorted { ($0.selectNumber ?? 0) < ($1.selectNumber ?? 0) }
+
+                copyState.currentSelectionCount = copyState.selectedPhotos.count
             }
             copyState.selectedLayout = layout
             state = copyState


### PR DESCRIPTION
## 🔗 연관된 이슈
- closed #188

## 📝 작업 내용

### 📌 요약
- 프레임 선택 완료 버튼 활성화 조건을 수정했습니다.
- 레이아웃 변경 시 선택 된 이미지가 초기화되는 기존 흐름을 `프레임에 들어갈 수 있는 사진의 개수`를 기준으로 하여 개수가 줄어들 경우 뒷부분만 초기화되도록 수정했습니다.

### 🔍 상세
- 기존 `isCompletedButtonDisabled` 프로퍼티는 `selectedPhotos`가 비어있지 않으면 활성화되므로 사용자가 1장 이상 선택 시 즉시 완료가 가능하다는 문제가 존재했습니다. (capacity와 무관합니다.)
   - 따라서 이를 `currentSelectionCount(현재 선택된 이미지의 개수)`가 `selectedLayout.capacity(현재 선택된 레이아웃의 용량, 2*2라면 4)`보다 작아야 `true`로 반환되도록 수정했습니다.

```swift
var isCompletedButtonDisabled: Bool {
    return currentSelectionCount < selectedLayout.capacity
}
```

- 기존 레이아웃 변경 시 동작 흐름은 `레이아웃 변경 시 모든 선택이 초기화`되고 있었습니다.

```swift
// 기존 흐름
case .setLayout(let layout):
    var copyState = state
    for index in 0 ..< copyState.photos.count {
        copyState.photos[index] = Photo(
            id: copyState.photos[index].id,
            url: copyState.photos[index].url,
            selectNumber: nil // 해당 시점에 사용자가 선택한 이미지의 번호가 초기화됩니다.
        )
    }
    copyState.selectedPhotos = []  // 여기에서 사용자가 선택한 사진의 배열이 비워지며
    copyState.currentSelectionCount = 0  // 카운트가 0으로 초기화됩니다
```

이를 레이아웃을 변경했을 시 반드시 초기화되는 흐름이 아닌 `이전(직전) 선택된 레이아웃의 용량(oldCapacity)`이 새롭게 선택된 레이아웃의 용량(newCapacity)`보다 작을 경우, 

즉 `개수가 줄어들 경우`와 동시에 현재 사용자가 선택한 이미지의 개수가 `새롭게 선택된 레이아웃의 용량(newCapacity)`보다 클 경우로 조건문을 추가했습니다.

## 📸 영상 / 이미지 (Optional)

### 수정 전

https://github.com/user-attachments/assets/4a899f28-e4d8-4d56-b93e-7240faa5436a

### 수정 후

https://github.com/user-attachments/assets/90e54533-679c-411f-be42-504d1a426f33
