### PR TITLE
[ui/#196] 스트리밍 뷰의 남은 사진 수 컴포넌트 가독성을 개선한다.

### DIFF
--- a/mirroringBooth/mirroringBooth/Device/Mirroring/Streaming/Component/CaptureCountBadge.swift
+++ b/mirroringBooth/mirroringBooth/Device/Mirroring/Streaming/Component/CaptureCountBadge.swift
@@ -14,22 +14,25 @@ struct CaptureCountBadge: View {
     let isCompact: Bool
 
     private var badgeSize: CGFloat {
-        isCompact ? 90 : 100
+        isCompact ? 110 : 120
     }
 
     var body: some View {
         VStack(spacing: 8) {
             Text("남은 촬영 횟수")
-                .font(isCompact ? .caption2 : .caption)
-                .opacity(0.8)
+                .font(isCompact ? .footnote : .subheadline)
             Text("\(total - current)")
-                .font(isCompact ? .title3 : .title)
+                .font(isCompact ? .title2 : .title)
         }
-        .foregroundStyle(.primary)
+        .foregroundStyle(.white)
         .frame(width: badgeSize, height: badgeSize)
+        .background {
+            Circle()
+                .fill(.thickMaterial)
+        }
         .overlay {
             Circle()
-                .strokeBorder(.white.opacity(0.3), lineWidth: 4)
+                .strokeBorder(.white, lineWidth: 3)
         }
     }
 }


### PR DESCRIPTION
## 🔗 연관된 이슈
- closed #196

## 📝 작업 내용

### 📌 요약
스트리밍 뷰의 남은 사진 수 컴포넌트의 가독성을 개선했습니다.
- 텍스트의 폰트 사이즈를 1단계씩 증가시켰습니다.
- 텍스트 색상과 원형 테두리를 하얀색으로 통일했습니다.
- background에 Material을 추가했습니다. (Material의 경우 Background와 Label 사이에 블렌딩 계층을 하나 추가하는 것으로 이해하고 있어서 성능엔 큰 이슈가 없을 것이라고 판단했습니다.)

## 📸 영상 / 이미지 (Optional)

https://github.com/user-attachments/assets/99ad4cc3-425d-432e-806f-e4e3173cd0ca
