### PR TITLE
design: 선택한 레이아웃, 프레임에 따라 표시하도록 UI 수정

### DIFF
--- a/mirroringBooth/mirroringBooth/Device/Mirroring/PhotoComposition/Component/FrameSelectionView.swift
+++ b/mirroringBooth/mirroringBooth/Device/Mirroring/PhotoComposition/Component/FrameSelectionView.swift
@@ -68,6 +68,13 @@ private extension FrameSelectionView {
                             store.send(.selectFrame(frame))
                         } label: {
                             frameIcon(with: frame, isSmall: false)
+                                .overlay {
+                                    RoundedRectangle(cornerRadius: 8)
+                                        .strokeBorder(
+                                            frame == store.state.selectedFrame ? Color.selectionBlue : .gray,
+                                            lineWidth: 2
+                                        )
+                                }
                         }
                     }
                 }
@@ -121,10 +128,12 @@ private extension FrameSelectionView {
                 Spacer()
             }
             .frame(maxWidth: .infinity)
-            .background {
-                RoundedRectangle(cornerRadius: 12)
-                    .fill(Color(.label).opacity(0.02))
-                    .strokeBorder(Color.borderLine, lineWidth: 2)
+            .overlay {
+                RoundedRectangle(cornerRadius: 8)
+                    .strokeBorder(
+                        frame == store.state.selectedFrame ? Color.selectionBlue : .gray,
+                        lineWidth: 2
+                    )
             }
         }
     }
@@ -132,23 +141,21 @@ private extension FrameSelectionView {
     @ViewBuilder
     func frameIcon(with frame: FrameAsset, isSmall: Bool) -> some View {
         if let icon = frame.image {
-            if isSmall {
-                Image(uiImage: icon)
-                    .resizable()
-                    .aspectRatio(1, contentMode: .fit)
-                    .frame(width: 30, height: 30)
-            } else {
-                Image(uiImage: icon)
-                    .resizable()
-                    .aspectRatio(1, contentMode: .fit)
-                    .frame(maxWidth: 50, maxHeight: 50)
-                    .padding(2)
-                    .background {
-                        RoundedRectangle(cornerRadius: 8)
-                            .strokeBorder(.primary, lineWidth: 2)
-                            .foregroundStyle(Color.secondary.opacity(0.6))
-                    }
+            Group {
+                if isSmall {
+                    Image(uiImage: icon)
+                        .resizable()
+                        .aspectRatio(1, contentMode: .fit)
+                        .frame(width: 30, height: 30)
+                } else {
+                    Image(uiImage: icon)
+                        .resizable()
+                        .aspectRatio(1, contentMode: .fit)
+                        .frame(maxWidth: 50, maxHeight: 50)
+                        .padding(2)
+                }
             }
+            .clipShape(RoundedRectangle(cornerRadius: 8))
         }
     }
 
@@ -160,16 +167,17 @@ private extension FrameSelectionView {
                 .resizable()
                 .renderingMode(.template)
                 .font(.footnote)
-                .foregroundStyle(Color.primary)
+                .foregroundStyle(iconString == store.state.selectedLayout.icon ? Color.selectionBlue : .gray)
                 .frame(maxWidth: 60, maxHeight: 60)
                 .padding(2)
                 .background {
                     RoundedRectangle(cornerRadius: 8)
-                        .strokeBorder(.primary, lineWidth: 2)
-                        .foregroundStyle(Color.secondary)
+                        .strokeBorder(
+                            iconString == store.state.selectedLayout.icon ? Color.selectionBlue : .gray,
+                            lineWidth: 2
+                        )
                 }
                 .aspectRatio(contentMode: .fit)
-                .opacity(0.6)
         }
     }
 }


### PR DESCRIPTION
## 🔗 연관된 이슈
- closed #201 

## 📝 작업 내용

### 📌 요약 && 🔍 상세
- 프레임과 레이아웃 버튼에서 현재 선택된 버전에 테두리 및 색을 추가하였습니다


## 💬 리뷰 노트
- 디자인 추천 받습니다 ㅎㅎ

## 📸 영상 / 이미지 (Optional)

<table>
  <tr>
    <td align="center">
      <img width="359" height="698" alt="compact-light" src="https://github.com/user-attachments/assets/e8f41a13-b33f-4d13-80c1-845d450f4929" />
      <br />
      compact - 라이트 모드
    </td>
    <td align="center">
      <img width="350" height="691" alt="compact-dark" src="https://github.com/user-attachments/assets/7c99dbc5-76cf-4856-99e6-cce8f3eac2d2" />
      <br />
      compact - 다크 모드
    </td>
  </tr>
  <tr>
    <td align="center">
      <img width="496" height="695" alt="large-light" src="https://github.com/user-attachments/assets/577e3da2-0f86-4aaf-b913-16b6e361b9e7" />
      <br />
      large - 라이트 모드
    </td>
    <td align="center">
      <img width="494" height="683" alt="large-dark" src="https://github.com/user-attachments/assets/eb6cda29-daa3-41f3-941c-b188a0012e39" />
      <br />
      large - 다크 모드
    </td>
  </tr>
</table>
