### PR TITLE
[fix/#222] 미러링 기기가 아이폰일 경우 스트리밍 뷰에서 표시되는 UI의 직관성을 개선한다.

### DIFF
--- a/mirroringBooth/mirroringBooth/Device/Mirroring/Streaming/Component/CaptureCountBadge.swift
+++ b/mirroringBooth/mirroringBooth/Device/Mirroring/Streaming/Component/CaptureCountBadge.swift
@@ -28,11 +28,12 @@ struct CaptureCountBadge: View {
         .frame(width: badgeSize, height: badgeSize)
         .background {
             Circle()
-                .fill(.thickMaterial)
+                .fill(.ultraThinMaterial)
         }
         .overlay {
             Circle()
                 .strokeBorder(.white, lineWidth: 3)
         }
+        .preferredColorScheme(.dark)
     }
 }

--- a/mirroringBooth/mirroringBooth/Device/Mirroring/Streaming/Component/StreamingOverlay.swift
+++ b/mirroringBooth/mirroringBooth/Device/Mirroring/Streaming/Component/StreamingOverlay.swift
@@ -97,7 +97,7 @@ struct ShootingProgressBadge: View {
 
     var body: some View {
         HStack(spacing: 16) {
-            ProgressIndicator(countdown: countdown, textColor: .white)
+            ProgressIndicator(countdown: countdown)
 
             VStack(alignment: .leading, spacing: 4) {
                 Text("NEXT SHOT")
@@ -121,7 +121,6 @@ struct ShootingProgressBadge: View {
 // 원형 프로그래스 인디케이터
 struct ProgressIndicator: View {
     let countdown: Int
-    var textColor: Color = .primary
 
     var body: some View {
         ZStack {
@@ -141,7 +140,7 @@ struct ProgressIndicator: View {
 
             Text("\(countdown)")
                 .font(.system(size: 24, weight: .bold))
-                .foregroundStyle(textColor)
+                .foregroundStyle(.white)
         }
     }
 }

--- a/mirroringBooth/mirroringBooth/Device/Mirroring/Streaming/StreamingView.swift
+++ b/mirroringBooth/mirroringBooth/Device/Mirroring/Streaming/StreamingView.swift
@@ -67,7 +67,7 @@ struct StreamingView: View {
                         .opacity(store.state.showCapturEffect ? 1.0 : 0.0)
                         .animation(.linear(duration: 0.2), value: store.state.showCapturEffect)
                 }
-                    .ignoresSafeArea()
+                .ignoresSafeArea()
             } else {
                 streamingPlaceholder
                     .ignoresSafeArea()
@@ -159,6 +159,10 @@ struct StreamingView: View {
 
                             if isCompact && isShooting {
                                 ProgressIndicator(countdown: store.state.shootingCountdown)
+                                    .background {
+                                        Circle()
+                                            .fill(.ultraThinMaterial)
+                                    }
                                     .padding(.top, 16)
                             }
                         }


### PR DESCRIPTION
## 🔗 연관된 이슈
- closed #222 

## 📝 작업 내용

### 📌 요약
- 남은 촬영 횟수를 나타내는 `CaptureCountBadge`를 다크모드 스타일로 고정했습니다.
   - 라이트모드에서 `Meterial` 배경이 `흰색`으로 블러처리됨과 동시에 흰색 텍스트로 인해 가독성이 저하되고 있었습니다.
   - 따라서 해당 컴포넌트만 `.preferredColorScheme(.dark)`을 추가하여 항상 다크모드 스타일로 표시되게 고정했습니다.
   - 기존 Material 타입도 `.thickMaterial`에서 `.ultraThinMaterial`로 변경해 더 자연스럽게 블러처리를 시켜 시각적으로 잘보이도록 개선했습니다.
- 현재 촬영 진행 현황을 원형 프로그래스 애니메이션으로 보여주는 `ProgressIndicator` 또한 텍스트 색상을 라이트모드, 다크모드 모두 `.white`로 고정했으며 불필요한 `textColor` 파라미터를 제거했습니다.
   - 해당 컴포넌트 또한 일관성을 위해 배경 Material에`.ultraThinMaterial`을 추가했습니다.

## 📸 영상 / 이미지 (Optional)

### 📌 아이폰 17 Pro Max

| 라이트모드 | 다크모드 |
|-----------|---------|
| <img width="471" height="989" alt="light" src="https://github.com/user-attachments/assets/499176f1-0e0a-4c20-a6d4-5c4c963da53f" /> | <img width="457" height="967" alt="dark" src="https://github.com/user-attachments/assets/42bf057c-1ec1-4468-82da-6d315547177c" /> |

---

### 📌 아이폰 SE

| 라이트모드 | 다크모드 |
|-----------|---------|
| <img width="417" height="865" alt="light" src="https://github.com/user-attachments/assets/849a985e-6165-4eaa-bfcd-f76c561d51bf" /> | <img width="415" height="879" alt="dark" src="https://github.com/user-attachments/assets/6681a718-9637-4b87-9527-5495ea3dbaf9" /> |

---

### 📌 아이패드

| 라이트모드 | 다크모드 |
|-----------|---------|
| <img width="2224" height="1668" alt="light" src="https://github.com/user-attachments/assets/12ede8e3-281f-4872-9ba1-2f0cac00d088" /> | <img width="2224" height="1668" alt="dark" src="https://github.com/user-attachments/assets/da5b05a2-c356-48f7-a678-62ff29d1ebd2" /> |

---

### 📌 맥북

| 라이트모드 | 다크모드 |
|-----------|---------|
| <img width="1110" height="855" alt="light" src="https://github.com/user-attachments/assets/510e67a5-7776-4059-a8aa-3edf2d18a7e0" /> | <img width="1105" height="861" alt="dark" src="https://github.com/user-attachments/assets/da395db8-f323-4ec0-9525-42915d4c5a5c" /> |
