### PR TITLE
[fix/#232] 카메라 프리뷰 외의 화면에서 세션이 살아있는 문제를 해결한다.

### DIFF
--- a/mirroringBooth/mirroringBooth/Device/Camera/Streaming/CameraPreview.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Streaming/CameraPreview.swift
@@ -67,6 +67,9 @@ struct CameraPreview: View {
                 rootStore?.browser?.sendCommand(.switchSelectModeView)
             }
         }
+        .onDisappear {
+            store.send(.stopCameraSession)
+        }
         .onChange(of: UIDevice.current.orientation.rawValue) { _, value in
             withAnimation(.easeInOut(duration: 0.3)) {
                 store.send(.updateAngle(rawValue: value))
@@ -86,7 +89,6 @@ struct CameraPreview: View {
             message: "기기 연결이 끊겼습니다.",
             cancellable: false
         ) {
-            store.send(.stopCameraSession)
             dismiss()
             router.reset()
         }

--- a/mirroringBooth/mirroringBooth/Device/Camera/Streaming/CameraPreviewStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Streaming/CameraPreviewStore.swift
@@ -71,7 +71,6 @@ final class CameraPreviewStore: StoreProtocol {
         case .updateAngle(let rawValue):
             return [.updateAngle(rawValue)]
         case .captureCompleted:
-            cameraManager.stopSession()
             browser.sendCommand(.allPhotosStored)
             return [.captureCompleted, .setTransferCount(0)]
         case .resetCaptureCompleted:


### PR DESCRIPTION
## 🔗 연관된 이슈
- closed #232 

## 📝 작업 내용

### 📌 요약
- 카메라 세션 종료 조건을 alert, .completed 대신 onDisappear로 통일하였습니다.
