### PR TITLE
[#234] 이름이 긴 디바이스가 연결되었을 때 기기명의 개행이 달라지는 문제를 해결한다

### DIFF
--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/Component/DeviceRow.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/Component/DeviceRow.swift
@@ -39,29 +39,28 @@ struct DeviceRow: View {
     }
 
     var body: some View {
-        HStack(spacing: 16) {
+        HStack(spacing: 0) {
             Image(systemName: device.type.icon)
                 .font(.title)
                 .foregroundStyle(iconColor)
                 .frame(width: iconFrameWidth, alignment: .center)
+                .padding(.trailing, 16)
 
             VStack(alignment: .leading) {
-                Text(device.id)
+                Text(device.id.replacingOccurrences(of: "(", with: "\n("))
                     .multilineTextAlignment(.leading)
                     .font(.headline.bold())
                 Text(device.type.rawValue)
                     .font(.footnote)
             }
 
-            Spacer()
+            Spacer(minLength: 8)
 
             // 선택된 기기인 경우 상징적인 아이콘 표시
-            if let target = selectedTarget {
-                Image(systemName: target.icon)
-                    .font(.title2)
-                    .foregroundStyle(Color(target.color))
-                    .frame(width: iconFrameWidth, alignment: .center)
-            }
+            Image(systemName: selectedTarget?.icon ?? "multiply")
+                .font(.title2)
+                .foregroundStyle(borderColor)
+                .frame(width: iconFrameWidth, alignment: .center)
         }
         .padding()
         .frame(maxWidth: .infinity)


### PR DESCRIPTION
## 🔗 연관된 이슈
- closed #234

## 📝 작업 내용

### 📌 요약 and 🔍 상세
- 여는 소괄호 앞에 개행 문자를 추가하였습니다
- 우측의 미러링 / 리모트 기기 위치에 이미지가 상시 위치하지만, 탭하지 않았을 경우 보이지 않도록 처리하여 선택 유무와 관계없이 상시 텍스트 형태가 고정되도록 처리하였습니다

## 📸 영상 / 이미지

- 가장 작은 기기에서 가장 긴 기기와, 괄호가 들어가는 임의의 기기를 테스트하였습니다

<table>
<tr>
<td align="center"><img width="411" height="875" alt="image" src="https://github.com/user-attachments/assets/039383b3-4869-429f-82c3-5751e1d06f3d" /></td>
<td align="center"><img width="411" height="875" alt="image" src="https://github.com/user-attachments/assets/3158f9a1-f3eb-4634-a553-57604298425a" /></td>
</tr>
<tr>
<td align="center"></td>
<td align="center"></td>
</tr>
</table>



