### PR TITLE
[feat/#245] 미러링 기기 찾는 중 화면에서 연결 전에는 안내 문구를 제공한다.

### DIFF
--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowsingView.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowsingView.swift
@@ -42,7 +42,10 @@ struct BrowsingView: View {
                     .font(.title2)
                     .bold()
 
-                Text(store.state.currentTarget.searchDescription)
+                Text(
+                    store.state.discoveredDevices.isEmpty ?
+                    "다른 기기에서 미러링/리모트 기기로 시작하기를 눌러주세요!" : store.state.currentTarget.searchDescription
+                )
                     .font(.footnote)
                     .foregroundStyle(Color(.secondaryLabel))
 


### PR DESCRIPTION
## 🔗 연관된 이슈
- closed #245

## 📝 작업 내용

### 📌 요약
- 검색된 기기가 없을 경우 '다른 기기에서 미러링/리모트 기기로 시작하기를 눌러주세요!' 문구를 표시합니다.

## 📸 영상 / 이미지 (Optional)

https://github.com/user-attachments/assets/aa7a49f0-db50-471b-9f4e-638d3ac25d8a

