### PR TITLE
[#261] TutorialView의 건너뛰기 버튼이 비활성화 된 듯한 UI를 수정한다.

### DIFF
--- a/mirroringBooth/mirroringBooth/Device/Common/Component/TutorialView.swift
+++ b/mirroringBooth/mirroringBooth/Device/Common/Component/TutorialView.swift
@@ -41,8 +41,8 @@ struct TutorialView: View {
                         .font(.headline)
                         .frame(maxWidth: 320)
                         .padding(.vertical, 14)
-                        .foregroundStyle(.black)
-                        .background(currentPage == imageNames.count - 1 ? .white : Color(.lightGray))
+                        .foregroundStyle(currentPage == imageNames.count - 1 ? .black : .white)
+                        .background(currentPage == imageNames.count - 1 ? .white : Color(.darkGray))
                         .clipShape(RoundedRectangle(cornerRadius: 12))
                 }
             }

--- a/mirroringBooth/mirroringBooth/Device/Common/Component/TutorialView.swift
+++ b/mirroringBooth/mirroringBooth/Device/Common/Component/TutorialView.swift
@@ -42,10 +42,9 @@ struct TutorialView: View {
                         .frame(maxWidth: 320)
                         .padding(.vertical, 14)
                         .foregroundStyle(.black)
-                        .background(.white)
+                        .background(currentPage == imageNames.count - 1 ? .white : Color(.lightGray))
                         .clipShape(RoundedRectangle(cornerRadius: 12))
                 }
-                .opacity(currentPage == imageNames.count - 1 ? 1 : 0.5)
             }
             .padding(.horizontal, 30)
             .padding(.vertical, 40)


### PR DESCRIPTION
## 🔗 연관된 이슈

- closed #261

## 📝 작업 내용

### 📌 요약

- TutorialView 건너뛰기 버튼 수정

### 🔍 상세

기존에는 건너뛰기 버튼의 배경 색상을 흰색으로 해두고, opacity를 0.5로 설정했습니다.

해당 버튼이 disabled 된 것 같다는 피드백에 따라 opacity 설정은 제거하고, 짙은 회색을 배경 색상으로 지정했습니다.

## 📸 영상 / 이미지

https://github.com/user-attachments/assets/e2a2c2ba-367e-4405-8858-064213387cb0

