### PR TITLE
[Refactor/#257] Browser의 클로저 콜백을 AsyncStream으로 개선한다. (1차 작업)

### DIFF
--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/Browser.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/Browser.swift
@@ -91,12 +91,17 @@ final class Browser: NSObject {
         UIDevice.current.userInterfaceIdiom == .phone
     }
 
+    let eventStream: AsyncStream<BrowserEvents>
+    private let eventContinuation: AsyncStream<BrowserEvents>.Continuation
+
     init(serviceType: String = "mirroringbooth") {
         self.serviceType = serviceType
         self.myDeviceName = PeerNameGenerator.makeDisplayName(isRandom: false, with: UIDevice.current.deviceType)
         self.peerID = MCPeerID(displayName: myDeviceName)
         self.browser = MCNearbyServiceBrowser(peer: peerID, serviceType: serviceType)
         self.mirroringHeartBeater = HeartBeater(repeatInterval: 1.0, timeout: 2.5)
+
+        (self.eventStream, self.eventContinuation) = AsyncStream.makeStream(of: BrowserEvents.self)
 
         super.init()
         browser.delegate = self

--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/Browser.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/Browser.swift
@@ -73,9 +73,6 @@ final class Browser: NSObject {
     /// 일괄 전송 시작 명령 수신 콜백
     var onStartTransferCommand = PassthroughSubject<Void, Never>()
 
-    /// 사진 보내기 성공 콜백
-    var onSendPhoto: (() -> Void)?
-
     /// 원격 모드 설정 명령 수신 콜백
     var onRemoteModeCommand: (() -> Void)?
 
@@ -220,7 +217,7 @@ final class Browser: NSObject {
                 if let error {
                     self.logger.warning("사진 전송 실패 : \(error.localizedDescription)")
                 } else {
-                    self.onSendPhoto?()
+                    self.eventContinuation.yield(.sendPhoto)
                     self.logger.info("사진 전송 완료: \(fileName)")
                 }
 

--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/Browser.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/Browser.swift
@@ -65,8 +65,6 @@ final class Browser: NSObject {
 
     var onDeviceConnected: ((NearbyDevice) -> Void)?
 
-    var onDeviceConnectionFailed: (() -> Void)?
-
     /// 촬영 명령 수신 콜백
     var onCaptureCommand: (() -> Void)?
 
@@ -398,7 +396,7 @@ extension Browser: MCSessionDelegate {
             onDeviceConnected?(device)
 
         case .notConnected:
-            onDeviceConnectionFailed?()
+            eventContinuation.yield(.deviceConnectionFailed)
             if isMirroringTarget || isMirroringCommandTarget {
                 targetMirroringDeviceID = nil
             }

--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/Browser.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/Browser.swift
@@ -65,9 +65,6 @@ final class Browser: NSObject {
 
     var onDeviceConnected: ((NearbyDevice) -> Void)?
 
-    /// 촬영 명령 수신 콜백
-    var onCaptureCommand: (() -> Void)?
-
     /// 일괄 전송 시작 명령 수신 콜백
     var onStartTransferCommand = PassthroughSubject<Void, Never>()
 
@@ -86,8 +83,13 @@ final class Browser: NSObject {
         UIDevice.current.userInterfaceIdiom == .phone
     }
 
-    let eventStream: AsyncStream<BrowserEvents>
-    private let eventContinuation: AsyncStream<BrowserEvents>.Continuation
+    /// 기기 검색 및 연결 전용 이벤트 스트림
+    let browsingEventStream: AsyncStream<BrowsingEvents>
+    private let browsingEventContinuation: AsyncStream<BrowsingEvents>.Continuation
+
+    /// 카메라 촬영 및 전송 전용 이벤트 스트림
+    let cameraStreamEventStream: AsyncStream<CameraStreamEvents>
+    private let cameraStreamEventContinuation: AsyncStream<CameraStreamEvents>.Continuation
 
     init(serviceType: String = "mirroringbooth") {
         self.serviceType = serviceType
@@ -96,7 +98,13 @@ final class Browser: NSObject {
         self.browser = MCNearbyServiceBrowser(peer: peerID, serviceType: serviceType)
         self.mirroringHeartBeater = HeartBeater(repeatInterval: 1.0, timeout: 2.5)
 
-        (self.eventStream, self.eventContinuation) = AsyncStream.makeStream(of: BrowserEvents.self)
+        (self.browsingEventStream, self.browsingEventContinuation) = AsyncStream.makeStream(
+            of: BrowsingEvents.self
+        )
+
+        (self.cameraStreamEventStream, self.cameraStreamEventContinuation) = AsyncStream.makeStream(
+            of: CameraStreamEvents.self
+        )
 
         super.init()
         browser.delegate = self
@@ -168,7 +176,8 @@ final class Browser: NSObject {
 
     /// 카메라 캡쳐 액션을 실행합니다.
     func capturePhoto() {
-        self.onCaptureCommand?()
+        print("촬영 진행")
+        cameraStreamEventContinuation.yield(.captureCommand)
         self.sendCommand(.onUpdateCaptureCount)
         self.sendCommand(.captureEffect)
     }
@@ -215,7 +224,7 @@ final class Browser: NSObject {
                 if let error {
                     self.logger.warning("사진 전송 실패 : \(error.localizedDescription)")
                 } else {
-                    self.eventContinuation.yield(.sendPhoto)
+                    self.cameraStreamEventContinuation.yield(.sendPhoto)
                     self.logger.info("사진 전송 완료: \(fileName)")
                 }
 
@@ -386,7 +395,7 @@ extension Browser: MCSessionDelegate {
     ) {
         let isMirroringTarget = session === mirroringSession && peerID.displayName == targetMirroringDeviceID
         let isMirroringCommandTarget = (session === mirroringCommandSession)
-            && (peerID.displayName == targetMirroringDeviceID)
+        && (peerID.displayName == targetMirroringDeviceID)
         let isRemoteTarget = session === remoteSession && peerID.displayName == targetRemoteDeviceID
 
         guard isMirroringTarget || isMirroringCommandTarget || isRemoteTarget else { return }
@@ -396,7 +405,7 @@ extension Browser: MCSessionDelegate {
             onDeviceConnected?(device)
 
         case .notConnected:
-            eventContinuation.yield(.deviceConnectionFailed)
+            browsingEventContinuation.yield(.deviceConnectionFailed)
             if isMirroringTarget || isMirroringCommandTarget {
                 targetMirroringDeviceID = nil
             }

--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/Browser.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/Browser.swift
@@ -176,7 +176,6 @@ final class Browser: NSObject {
 
     /// 카메라 캡쳐 액션을 실행합니다.
     func capturePhoto() {
-        print("촬영 진행")
         cameraStreamEventContinuation.yield(.captureCommand)
         self.sendCommand(.onUpdateCaptureCount)
         self.sendCommand(.captureEffect)

--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowserEvents.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowserEvents.swift
@@ -14,15 +14,15 @@ enum BrowserEvents {
     case deviceLost(NearbyDevice)
     case deviceConnected(NearbyDevice)
     case deviceConnectionFailed
-    
+
     // 카메라
     case captureCommand
     case sendPhoto
-    
+
     // 리모트 모드
     case remoteModeCommand
     case selectedTimerModeCommand
-    
+
     // Heartbeat
     case heartbeatTimeout
     case remoteHeartbeatTimeout

--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowserEvents.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowserEvents.swift
@@ -13,11 +13,11 @@ enum BrowserEvents {
     case deviceFound(NearbyDevice)
     case deviceLost(NearbyDevice)
     case deviceConnected(NearbyDevice)
-    case deviceConnectionFailed
+    case deviceConnectionFailed // 마이그레이션 완료 (모든 콜백 마이그레이션 후 해당 주석은 제거될 예정입니다.)
 
     // 카메라
     case captureCommand
-    case sendPhoto
+    case sendPhoto // 마이그레이션 완료
 
     // 리모트 모드
     case remoteModeCommand

--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowserEvents.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowserEvents.swift
@@ -7,21 +7,26 @@
 
 import Foundation
 
-/// Browser에서 발생하는 모든 이벤트 타입을 정의합니다.
-enum BrowserEvents {
+enum BrowsingEvents {
     // 기기 발견/연결
     case deviceFound(NearbyDevice)
     case deviceLost(NearbyDevice)
     case deviceConnected(NearbyDevice)
-    case deviceConnectionFailed // 마이그레이션 완료 (모든 콜백 마이그레이션 후 해당 주석은 제거될 예정입니다.)
-
-    // 카메라
-    case captureCommand
-    case sendPhoto // 마이그레이션 완료
+    case deviceConnectionFailed // 마이그레이션 완료
 
     // 리모트 모드
     case remoteModeCommand
     case selectedTimerModeCommand
+
+    // Heartbeat
+    case heartbeatTimeout
+    case remoteHeartbeatTimeout
+}
+
+enum CameraStreamEvents {
+    // 촬영
+    case captureCommand // 마이그레이션 완료
+    case sendPhoto // 마이그레이션 완료
 
     // Heartbeat
     case heartbeatTimeout

--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowserEvents.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowserEvents.swift
@@ -1,0 +1,29 @@
+//
+//  Browser.swift
+//  mirroringBooth
+//
+//  Created by 윤대현 on 2026-02-02.
+//
+
+import Foundation
+
+/// Browser에서 발생하는 모든 이벤트 타입을 정의합니다.
+enum BrowserEvents {
+    // 기기 발견/연결
+    case deviceFound(NearbyDevice)
+    case deviceLost(NearbyDevice)
+    case deviceConnected(NearbyDevice)
+    case deviceConnectionFailed
+    
+    // 카메라
+    case captureCommand
+    case sendPhoto
+    
+    // 리모트 모드
+    case remoteModeCommand
+    case selectedTimerModeCommand
+    
+    // Heartbeat
+    case heartbeatTimeout
+    case remoteHeartbeatTimeout
+}

--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowsingStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowsingStore.swift
@@ -41,7 +41,7 @@ final class BrowsingStore: StoreProtocol {
         case setShowMirroringDisconnectedAlert(Bool)
         case setShowToast(Bool)
         case setShowTutorial(Bool)
-        case browserEvent(BrowserEvents)
+        case browserEvent(BrowsingEvents)
     }
 
     enum Result {
@@ -62,8 +62,8 @@ final class BrowsingStore: StoreProtocol {
     let watchConnectionManager: WatchConnectionManager
     private var cancellables = Set<AnyCancellable>()
 
-    var eventStream: AsyncStream<BrowserEvents> {
-        browser.eventStream
+    var eventStream: AsyncStream<BrowsingEvents> {
+        browser.browsingEventStream
     }
 
     init(_ browser: Browser, _ watchConnectionManager: WatchConnectionManager) {
@@ -240,8 +240,8 @@ final class BrowsingStore: StoreProtocol {
         return result
     }
 
-    // View에서 전달받은 BrowserEvents를 처리하여 Result로 변환합니다.
-    private func handleBrowserEvent(_ event: BrowserEvents) -> [Result] {
+    // View에서 전달받은 BrowsingEvents를 처리하여 Result로 변환합니다.
+    private func handleBrowserEvent(_ event: BrowsingEvents) -> [Result] {
         switch event {
         case .deviceConnectionFailed:
             return [.setIsConnecting(false)]

--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowsingStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowsingStore.swift
@@ -41,6 +41,7 @@ final class BrowsingStore: StoreProtocol {
         case setShowMirroringDisconnectedAlert(Bool)
         case setShowToast(Bool)
         case setShowTutorial(Bool)
+        case browserEvent(BrowserEvents)
     }
 
     enum Result {
@@ -60,6 +61,10 @@ final class BrowsingStore: StoreProtocol {
     let browser: Browser
     let watchConnectionManager: WatchConnectionManager
     private var cancellables = Set<AnyCancellable>()
+
+    var eventStream: AsyncStream<BrowserEvents> {
+        browser.eventStream
+    }
 
     init(_ browser: Browser, _ watchConnectionManager: WatchConnectionManager) {
         self.browser = browser
@@ -91,10 +96,6 @@ final class BrowsingStore: StoreProtocol {
             case .none:
                 break
             }
-            self?.reduce(.setIsConnecting(false))
-        }
-
-        browser.onDeviceConnectionFailed = { [weak self] in
             self?.reduce(.setIsConnecting(false))
         }
 
@@ -231,9 +232,22 @@ final class BrowsingStore: StoreProtocol {
 
         case .setShowTutorial(let value):
             result.append(.setShowTutorial(value))
+
+        case .browserEvent(let event):
+            result.append(contentsOf: handleBrowserEvent(event))
         }
 
         return result
+    }
+
+    // View에서 전달받은 BrowserEvents를 처리하여 Result로 변환합니다.
+    private func handleBrowserEvent(_ event: BrowserEvents) -> [Result] {
+        switch event {
+        case .deviceConnectionFailed:
+            return [.setIsConnecting(false)]
+        default:
+            return []
+        }
     }
 
     func reduce(_ result: Result) {

--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowsingView.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowsingView.swift
@@ -129,6 +129,11 @@ struct BrowsingView: View {
         .onDisappear {
             store.send(.exit)
         }
+        .task {
+            for await event in store.eventStream {
+                store.send(.browserEvent(event))
+            }
+        }
         .onChange(of: scenePhase) { _, newValue in
             let state: UIApplication.State
             switch newValue {

--- a/mirroringBooth/mirroringBooth/Device/Camera/Streaming/CameraPreview.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Streaming/CameraPreview.swift
@@ -87,6 +87,11 @@ struct CameraPreview: View {
             store.send(.setColorScheme(nil))
             store.send(.stopCameraSession)
         }
+        .task {
+            for await event in store.eventStream {
+                store.send(.browserEvent(event))
+            }
+        }
         .onChange(of: UIDevice.current.orientation.rawValue) { _, value in
             withAnimation(.easeInOut(duration: 0.3)) {
                 store.send(.updateAngle(rawValue: value))

--- a/mirroringBooth/mirroringBooth/Device/Camera/Streaming/CameraPreviewStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Streaming/CameraPreviewStore.swift
@@ -92,6 +92,7 @@ final class CameraPreviewStore: StoreProtocol {
         case .browserEvent(let event):
             return handleBrowserEvent(event)
         }
+        return []
     }
 
     func reduce(_ result: Result) {

--- a/mirroringBooth/mirroringBooth/Device/Camera/Streaming/CameraPreviewStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Streaming/CameraPreviewStore.swift
@@ -34,7 +34,7 @@ final class CameraPreviewStore: StoreProtocol {
         case isMirroringDisconnected
         case setTransferCount(Int)
         case setColorScheme(ColorScheme?)
-        case browserEvent(BrowserEvents)
+        case browserEvent(CameraStreamEvents)
     }
 
     enum Result {
@@ -53,8 +53,8 @@ final class CameraPreviewStore: StoreProtocol {
     private(set) var state: State
     private var cancellables = Set<AnyCancellable>()
 
-    var eventStream: AsyncStream<BrowserEvents> {
-        browser.eventStream
+    var eventStream: AsyncStream<CameraStreamEvents> {
+        browser.cameraStreamEventStream
     }
 
     init(
@@ -122,11 +122,14 @@ final class CameraPreviewStore: StoreProtocol {
         self.state = state
     }
 
-    // View에서 전달받은 BrowserEvents를 처리하여 Result로 변환합니다.
-    private func handleBrowserEvent(_ event: BrowserEvents) -> [Result] {
+    // View에서 전달받은 CameraStreamEvents를 처리하여 Result로 변환합니다.
+    private func handleBrowserEvent(_ event: CameraStreamEvents) -> [Result] {
         switch event {
         case .sendPhoto:
             return [.setTransferCount(state.transfercount + 1)]
+        case .captureCommand:
+            cameraManager.capturePhoto(getOrientationByAngle(state.angle))
+            return []
         default:
             return []
         }
@@ -146,12 +149,6 @@ private extension CameraPreviewStore {
             framedData.append(data)
 
             self.browser.sendStreamData(framedData)
-        }
-        // 촬영 명령 수신
-        browser.onCaptureCommand = {
-            self.cameraManager.capturePhoto(
-                self.getOrientationByAngle(self.state.angle)
-            )
         }
         // 일괄 전송 시작 명령 수신
         browser.onStartTransferCommand

--- a/mirroringBooth/mirroringBooth/Device/Camera/Streaming/CameraPreviewStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Streaming/CameraPreviewStore.swift
@@ -34,6 +34,7 @@ final class CameraPreviewStore: StoreProtocol {
         case isMirroringDisconnected
         case setTransferCount(Int)
         case setColorScheme(ColorScheme?)
+        case browserEvent(BrowserEvents)
     }
 
     enum Result {
@@ -51,6 +52,10 @@ final class CameraPreviewStore: StoreProtocol {
     private let cameraManager: CameraManager
     private(set) var state: State
     private var cancellables = Set<AnyCancellable>()
+
+    var eventStream: AsyncStream<BrowserEvents> {
+        browser.eventStream
+    }
 
     init(
         browser: Browser,
@@ -83,9 +88,10 @@ final class CameraPreviewStore: StoreProtocol {
         case .setTransferCount(let count):
             return [.setTransferCount(count)]
         case .setColorScheme(let scheme):
-            return [.setColorScheme(scheme) ]
+            return [.setColorScheme(scheme)]
+        case .browserEvent(let event):
+            return handleBrowserEvent(event)
         }
-        return []
     }
 
     func reduce(_ result: Result) {
@@ -113,6 +119,16 @@ final class CameraPreviewStore: StoreProtocol {
         }
 
         self.state = state
+    }
+
+    // View에서 전달받은 BrowserEvents를 처리하여 Result로 변환합니다.
+    private func handleBrowserEvent(_ event: BrowserEvents) -> [Result] {
+        switch event {
+        case .sendPhoto:
+            return [.setTransferCount(state.transfercount + 1)]
+        default:
+            return []
+        }
     }
 }
 
@@ -145,11 +161,6 @@ private extension CameraPreviewStore {
                 self.cameraManager.sendAllPhotos(using: self.browser)
             }
             .store(in: &cancellables)
-        // 장당 전송 완료
-        browser.onSendPhoto = { [weak self] in
-            guard let self else { return }
-            self.send(.setTransferCount(self.state.transfercount + 1))
-        }
 
         // 전송 완료
         cameraManager.onTransferCompleted = {


### PR DESCRIPTION
## 🔗 연관된 이슈
> 이슈 번호를 입력해주세요. (예: #12)
> 이슈가 완전히 해결되었다면 아래에 예약어를 남겨주세요.
- closed #257 

## 📝 작업 내용

### 📌 요약
- `AsyncStream`을 선택하게 된 이유는 아래 링크를 참고해주세요! (귀로님과 함께 이야기했습니다.)
[Advertiser, Browser 개조](https://github.com/boostcampwm2025/iOS03-dolAwang/wiki/%F0%9F%93%9F-Advertiser-Browser-%EA%B0%9C%EC%A1%B0(%EC%BD%9C%EB%B0%B1-%EC%A0%9C%EA%B1%B0))
- `AsyncStream`에 대해 학습 정리한 내용은 아래와 같습니다. 참고해주세요!
[AsyncStream에 대해 알아보자](https://daegom.notion.site/AsyncStream-2fb1833ac00380168aa6f7d6a4f2dacf?source=copy_link)

AsyncStream으로 마이그레이션 할 클로저 콜백은 아래와 같습니다.


이벤트 | 현재 | 변경 후
-- | -- | --
onDeviceFound | 클로저 | AsyncStream
onDeviceLost | 클로저 | AsyncStream
onDeviceConnected | 클로저 | AsyncStream
onDeviceConnectionFailed | 클로저 | AsyncStream
onCaptureCommand | 클로저 | AsyncStream
onSendPhoto | 클로저 | AsyncStream
onRemoteModeCommand | 클로저 | AsyncStream
onSelectedTimerModeCommand | 클로저 | AsyncStream
onHeartbeatTimeout | 클로저 | AsyncStream
onRemoteHeartbeatTimeout | 클로저 | AsyncStream
onStartTransferCommand | Combine | Combine

이때, `onStartTransferCommand`의 경우 현재 Combine을 사용해서 적절하게 이벤트를 전파중이므로 AsyncStream으로 변경하지 않는 방향이 올바르다고 판단했지만.. 해당 방식 또한 AsyncStream으로 변경해야할까요? 👀 이 부분은 의견을 여쭙고 싶습니다.

또한, 현재 Browser에선 makeStream을 통해 2개의 이벤트 스트림을 생성하고 있습니다.  
기본적으로 AsyncStream은 단일 소비자용이며 `브로드캐스팅`이 불가능한 구조를 가지고 있습니다.  

따라서 단일 이벤트 스트림보단 현재 클로저 콜백은 명확하게 `기기 연결`과 `카메라 로직` 2개로 구분지어 있으므로  
이와 대응되게 이벤트와 더불어 이벤트 스트림을 분리했습니다.

또한 Advetsier와 달리 Browser에서 사용 중인 AsyncStream의 버퍼 스트림 정책은 기본값인 `.unbounded`입니다.  

이때, 따로 버퍼 프록시 정책을 `bufferingOldest`나 `bufferingNewest`로 설정하지 않은 이유는
Browser의 핵심 이벤트들인 `deviceFound` , `deviceConnected`, `captureCommand`, `heartbeatTimeout`과 같은 요소들이 대부분 1회성 이벤트이기도 하며
  
`for await in` 구문을 통해 이벤트가 발생되자마자 즉시 `소비` 되기 떄문에

- 버퍼에 무한정 쌓일 가능성이 있을까? → ❌
- 이벤트가 초당 수백 ~ 수천번 생길까? → ❌
- 처리 시간이 매우 길까? → ❌
- 결정적으로 현재 Browser를 구성하는 이벤트들은 `단 하나라도 사라지면 안되는 요소` 라고 판단했습니다.

따라서 AsyncStream을 생성할 때 버퍼 정책을 기본값인 `.unbounded`로 둬서 `버퍼에 쌓이는 데이터의 개수 제한이 없도록` 의도했습니다.
  
## 💬 리뷰 노트
> 본래.. 테스트 코드를 통해 동등성을 검증하려 했지만.. 제 맥북의 원인인지.. 테스트 타겟을 추가하니 자꾸 Xcode가 터져버리고 있습니다..  
> 가급적 빠른 시일 내에 테스트 코드 집어넣겠습니다..  ㅠㅠ
- 현재 마이그레이션 된 클로저 콜백은 아래와 같습니다.

| 이벤트 | 현재 | 변경 후 | 마이그레이션 완료 |
|-------|------|--------|----------------|
| onDeviceFound | 클로저 | AsyncStream | ❌ |
| onDeviceLost | 클로저 | AsyncStream | ❌ |
| onDeviceConnected | 클로저 | AsyncStream | ❌ |
| onDeviceConnectionFailed | 클로저 | AsyncStream | ✅ |
| onCaptureCommand | 클로저 | AsyncStream | ✅ |
| onSendPhoto | 클로저 | AsyncStream | ✅ |
| onRemoteModeCommand | 클로저 | AsyncStream | ❌ |
| onSelectedTimerModeCommand | 클로저 | AsyncStream | ❌ |
| onHeartbeatTimeout | 클로저 | AsyncStream | ❌ |
| onRemoteHeartbeatTimeout | 클로저 | AsyncStream | ❌ |

작업과 수정되는 부분이 상당히 많을 것으로 예상되어 PR을 분리했습니다.

나머지 작업은 이어서 바로 진행할 예정입니다.

또한, 현재 개선된 3가지 콜백들은 콜백 당 3번 이상의 실기기 테스트를 위해 기존과 동등한 로직이 이쁘게(?) 잘 동작하는 것을 확인했습니다.