### PR TITLE
[Refactor/#272] Advertiser의 제어 콜백을 AsyncStream으로 개선한다.

### DIFF
--- a/mirroringBooth/mirroringBooth/App/RootStore.swift
+++ b/mirroringBooth/mirroringBooth/App/RootStore.swift
@@ -26,7 +26,7 @@ final class RootStore: StoreProtocol {
     var advertiser: Advertiser? {
         didSet {
             commandTask?.cancel()
-            setListner()
+            setListener()
         }
     }
     var browser: Browser?
@@ -58,7 +58,7 @@ final class RootStore: StoreProtocol {
 }
 
 extension RootStore {
-    private func setListner() {
+    private func setListener() {
         guard let advertiser else { return }
         commandTask = Task { [weak self] in
             for await stream in advertiser.rootStream {

--- a/mirroringBooth/mirroringBooth/App/RootStore.swift
+++ b/mirroringBooth/mirroringBooth/App/RootStore.swift
@@ -23,8 +23,18 @@ final class RootStore: StoreProtocol {
     }
 
     private(set) var state: State = .init()
-    var advertiser: Advertiser?
+    var advertiser: Advertiser? {
+        didSet {
+            commandTask?.cancel()
+            setListner()
+        }
+    }
     var browser: Browser?
+    private var commandTask: Task<Void, Never>?
+
+    deinit {
+        commandTask?.cancel()
+    }
 
     func action(_ intent: Intent) -> [Result] {
         switch intent {
@@ -43,6 +53,22 @@ final class RootStore: StoreProtocol {
         switch result {
         case let .showTimeoutAlert(bool):
             state.showTimeoutAlert = bool
+        }
+    }
+}
+
+extension RootStore {
+    private func setListner() {
+        guard let advertiser else { return }
+        commandTask = Task { [weak self] in
+            for await stream in advertiser.rootStream {
+                switch stream {
+                case .onHeartbeatTimeout:
+                    await MainActor.run {
+                        self?.send(.showTimeoutAlert(true))
+                    }
+                }
+            }
         }
     }
 }

--- a/mirroringBooth/mirroringBooth/App/RootView.swift
+++ b/mirroringBooth/mirroringBooth/App/RootView.swift
@@ -49,11 +49,6 @@ struct RootView: View {
                                 }
                             }
                         }
-                        .onAppear {
-                            store.advertiser?.onHeartBeatTimeout = {
-                                store.send(.showTimeoutAlert(true))
-                            }
-                        }
 
                     case .poseSuggestionSelection(let isTimerMode):
                         ModeSelectionView(
@@ -82,11 +77,6 @@ struct RootView: View {
                     switch viewType {
                     case .remoteCapture(let advertiser):
                         RemoteCaptureView(advertiser: advertiser)
-                            .onAppear {
-                                store.advertiser?.onHeartBeatTimeout = {
-                                    store.send(.showTimeoutAlert(true))
-                                }
-                            }
 
                     case .completion:
                         CompletionView {

--- a/mirroringBooth/mirroringBooth/App/RootView.swift
+++ b/mirroringBooth/mirroringBooth/App/RootView.swift
@@ -40,13 +40,18 @@ struct RootView: View {
                             for: .timerOrRemote,
                             flag: isRemoteEnable
                         )
+                        .task {
+                            guard let advertiser = store.advertiser else { return }
+                            for await stream in advertiser.modeSelectionStream {
+                                if case .switchModeSelectionView = stream {
+                                    router.pop()
+                                    router.push(to: MirroringRoute.timerOrRemoteSelection(isRemoteEnable: false))
+                                }
+                            }
+                        }
                         .onAppear {
                             store.advertiser?.onHeartBeatTimeout = {
                                 store.send(.showTimeoutAlert(true))
-                            }
-                            store.advertiser?.switchModeSelectionView = {
-                                router.pop()
-                                router.push(to: MirroringRoute.timerOrRemoteSelection(isRemoteEnable: false))
                             }
                         }
 

--- a/mirroringBooth/mirroringBooth/Core/StoreProtocol.swift
+++ b/mirroringBooth/mirroringBooth/Core/StoreProtocol.swift
@@ -18,12 +18,11 @@ protocol StoreProtocol: AnyObject {
 }
 
 extension StoreProtocol {
+    @MainActor
     func send(_ intent: Intent) {
         let results = action(intent)
-        Task { @MainActor in
-            for result in results {
-                reduce(result)
-            }
+        for result in results {
+            reduce(result)
         }
     }
 }

--- a/mirroringBooth/mirroringBooth/Core/StoreProtocol.swift
+++ b/mirroringBooth/mirroringBooth/Core/StoreProtocol.swift
@@ -18,11 +18,12 @@ protocol StoreProtocol: AnyObject {
 }
 
 extension StoreProtocol {
-    @MainActor
     func send(_ intent: Intent) {
         let results = action(intent)
-        for result in results {
-            reduce(result)
+        Task { @MainActor in
+            for result in results {
+                reduce(result)
+            }
         }
     }
 }

--- a/mirroringBooth/mirroringBooth/Device/Common/HeartBeater/Advertiser+HeartBeater.swift
+++ b/mirroringBooth/mirroringBooth/Device/Common/HeartBeater/Advertiser+HeartBeater.swift
@@ -18,8 +18,6 @@ extension Advertiser: HeartBeaterDelegate {
     }
 
     func onTimeout(_ sender: HeartBeater) {
-        DispatchQueue.main.async {
-            self.onHeartBeatTimeout?()
-        }
+        rootContinuation.yield(.onHeartbeatTimeout)
     }
 }

--- a/mirroringBooth/mirroringBooth/Device/Mirroring/Streaming/StreamingStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Mirroring/Streaming/StreamingStore.swift
@@ -139,13 +139,6 @@ final class StreamingStore: StoreProtocol {
             return
         }
 
-        // 10장 사진 저장 시작
-        advertiser.onAllPhotosStored = { [weak self] in
-            Task { @MainActor in
-                self?.send(.startTransfer)
-            }
-        }
-
         // 카메라 캡쳐 이펙트
         advertiser.onCaptureEffect = { [weak self] in
             Task { @MainActor in
@@ -298,6 +291,8 @@ extension StreamingStore {
                     self?.send(.photoReceived)
                 case .onUpdateCaptureCount:
                     self?.send(.capturePhotoCount)
+                case .onAllPhotosStored:
+                    self?.send(.startTransfer)
                 }
             }
         }

--- a/mirroringBooth/mirroringBooth/Device/Mirroring/Streaming/StreamingStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Mirroring/Streaming/StreamingStore.swift
@@ -343,10 +343,9 @@ extension StreamingStore {
 
 // MARK: - 캡쳐 이펙트
 extension StreamingStore {
-    @MainActor
     func captureEffect() {
         self.send(.setShowCaptureEffect(true))
-        Task { @MainActor [weak self] in
+        Task { [weak self] in
             try? await Task.sleep(nanoseconds: 200_000_000)
             self?.send(.setShowCaptureEffect(false))
         }

--- a/mirroringBooth/mirroringBooth/Device/Mirroring/Streaming/StreamingStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Mirroring/Streaming/StreamingStore.swift
@@ -133,6 +133,7 @@ final class StreamingStore: StoreProtocol {
                 self?.reduce(.videoFrameDecoded(sampleBuffer, rotationAngle))
             }
         }
+        startListening()
     }
 
     func action(_ intent: Intent) -> [Result] {

--- a/mirroringBooth/mirroringBooth/Device/Mirroring/Streaming/StreamingStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Mirroring/Streaming/StreamingStore.swift
@@ -6,8 +6,8 @@
 //
 
 import AVFoundation
-import SwiftUI
 import OSLog
+import SwiftUI
 
 @Observable
 final class StreamingStore: StoreProtocol {
@@ -117,6 +117,7 @@ final class StreamingStore: StoreProtocol {
     private let decoder: H264Decoder
     private var timer: Timer?
     private var streamingTask: Task<Void, Never>?
+    private var commandTask: Task<Void, Never>?
 
     init(
         _ advertiser: Advertiser?,
@@ -136,19 +137,6 @@ final class StreamingStore: StoreProtocol {
         guard let advertiser else {
             Logger.streamingStore.error("advertiser가 없어 정상 동작하지 않습니다.")
             return
-        }
-
-        // 사진 수신 콜백
-        advertiser.onPhotoReceived = { [weak self] in
-            Task { @MainActor in
-                self?.send(.photoReceived)
-            }
-        }
-
-        advertiser.onUpdateCaptureCount = { [weak self] in
-            Task { @MainActor in
-                self?.send(.capturePhotoCount)
-            }
         }
 
         // 10장 사진 저장 시작
@@ -300,6 +288,16 @@ extension StreamingStore {
             for await stream in advertiser.videoStream {
                 if case .streamDataReceived(let data) = stream {
                     self?.decoder.decode(data)
+                }
+            }
+        }
+        commandTask = Task { [weak self] in
+            for await stream in advertiser.streamingStoreStream {
+                switch stream {
+                case .onPhotoReceived:
+                    self?.send(.photoReceived)
+                case .onUpdateCaptureCount:
+                    self?.send(.capturePhotoCount)
                 }
             }
         }

--- a/mirroringBooth/mirroringBooth/Device/Mirroring/Streaming/StreamingStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Mirroring/Streaming/StreamingStore.swift
@@ -133,18 +133,6 @@ final class StreamingStore: StoreProtocol {
                 self?.reduce(.videoFrameDecoded(sampleBuffer, rotationAngle))
             }
         }
-
-        guard let advertiser else {
-            Logger.streamingStore.error("advertiser가 없어 정상 동작하지 않습니다.")
-            return
-        }
-
-        // 카메라 캡쳐 이펙트
-        advertiser.onCaptureEffect = { [weak self] in
-            Task { @MainActor in
-                self?.captureEffect()
-            }
-        }
     }
 
     func action(_ intent: Intent) -> [Result] {
@@ -293,6 +281,8 @@ extension StreamingStore {
                     self?.send(.capturePhotoCount)
                 case .onAllPhotosStored:
                     self?.send(.startTransfer)
+                case .onCaptureEffect:
+                    self?.captureEffect()
                 }
             }
         }

--- a/mirroringBooth/mirroringBooth/Device/Mirroring/Streaming/StreamingStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Mirroring/Streaming/StreamingStore.swift
@@ -273,7 +273,7 @@ extension StreamingStore {
                 }
             }
         }
-        commandTask = Task { [weak self] in
+        commandTask = Task { @MainActor [weak self] in
             for await stream in advertiser.streamingStoreStream {
                 switch stream {
                 case .onPhotoReceived:
@@ -343,9 +343,10 @@ extension StreamingStore {
 
 // MARK: - 캡쳐 이펙트
 extension StreamingStore {
+    @MainActor
     func captureEffect() {
         self.send(.setShowCaptureEffect(true))
-        Task { [weak self] in
+        Task { @MainActor [weak self] in
             try? await Task.sleep(nanoseconds: 200_000_000)
             self?.send(.setShowCaptureEffect(false))
         }

--- a/mirroringBooth/mirroringBooth/Device/Mirroring/Streaming/StreamingStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Mirroring/Streaming/StreamingStore.swift
@@ -280,7 +280,7 @@ extension StreamingStore {
                     self?.send(.photoReceived)
                 case .onUpdateCaptureCount:
                     self?.send(.capturePhotoCount)
-                case .onAllPhotosStored:
+                case .onStoreAllPhotos:
                     self?.send(.startTransfer)
                 case .onCaptureEffect:
                     self?.captureEffect()

--- a/mirroringBooth/mirroringBooth/Device/Remote/RemoteCaptureView.swift
+++ b/mirroringBooth/mirroringBooth/Device/Remote/RemoteCaptureView.swift
@@ -20,13 +20,13 @@ struct RemoteCaptureView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
         .backgroundStyle()
-        .onAppear {
-            advertiser.navigateToRemoteCompleteCallBack = { [weak router] in
-                router?.push(to: RemoteRoute.completion)
-            }
-        }
         .task {
-            
+            for await stream in advertiser.remoteCaptureViewStream {
+                switch stream {
+                case .navigateToRemoteComplete:
+                    router.push(to: RemoteRoute.completion)
+                }
+            }
         }
     }
 }

--- a/mirroringBooth/mirroringBooth/Device/Remote/RemoteCaptureView.swift
+++ b/mirroringBooth/mirroringBooth/Device/Remote/RemoteCaptureView.swift
@@ -25,5 +25,8 @@ struct RemoteCaptureView: View {
                 router?.push(to: RemoteRoute.completion)
             }
         }
+        .task {
+            
+        }
     }
 }

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Advertiser.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Advertiser.swift
@@ -40,6 +40,9 @@ final class Advertiser: NSObject {
     private let remoteCaptureViewContinuation: AsyncStream<RemoteCaptureViewEvents>.Continuation
     let remoteCaptureViewStream: AsyncStream<RemoteCaptureViewEvents>
 
+    private let streamingStoreContinuation: AsyncStream<StreamingStoreEvents>.Continuation
+    let streamingStoreStream: AsyncStream<StreamingStoreEvents>
+
     /// 카메라 기기에게 보내는 명령
     enum CameraDeviceCommand: String {
         case capturePhoto  // 사진 촬영
@@ -50,12 +53,6 @@ final class Advertiser: NSObject {
         case remoteHeartBeat // 리모트 세션 확인용
         case stopHeartBeat // heartbeat 종료
     }
-
-    /// 사진 수신 완료 콜백 (1장마다 호출)
-    var onPhotoReceived: (() -> Void)?
-
-    /// 캡쳐 요청 카운트 콜백 (촬영기기에서 전송)
-    var onUpdateCaptureCount: (() -> Void)?
 
     /// 10장 모두 저장 완료 콜백 (촬영기기에서 전송)
     var onAllPhotosStored: (() -> Void)?
@@ -108,6 +105,7 @@ final class Advertiser: NSObject {
         (remoteCaptureViewStream, remoteCaptureViewContinuation) = AsyncStream.makeStream(
             of: RemoteCaptureViewEvents.self
         )
+        (streamingStoreStream, streamingStoreContinuation) = AsyncStream.makeStream(of: StreamingStoreEvents.self)
 
         super.init()
         advertiser.delegate = self
@@ -196,9 +194,7 @@ final class Advertiser: NSObject {
                 self.onAllPhotosStored?()
             }
         case .onUpdateCaptureCount:
-            DispatchQueue.main.async {
-                self.onUpdateCaptureCount?()
-            }
+            streamingStoreContinuation.yield(.onUpdateCaptureCount)
         case .heartBeat:
             heartBeater.beat()
         case .captureEffect:
@@ -294,9 +290,7 @@ extension Advertiser: MCSessionDelegate {
             }
         }
         /// 사진 수신 완료
-        DispatchQueue.main.async {
-            self.onPhotoReceived?()
-        }
+        streamingStoreContinuation.yield(.onPhotoReceived)
     }
 }
 

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Advertiser.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Advertiser.swift
@@ -34,14 +34,12 @@ final class Advertiser: NSObject {
     private let modeSelectionContinuation: AsyncStream<ModeSelectionEvents>.Continuation
     let modeSelectionStream: AsyncStream<ModeSelectionEvents>
 
-    /// 촬영 화면 이동 콜백 (리모트 기기)
-    var navigateToRemoteCaptureCallBack: (() -> Void)?
+    private let remoteConnectedViewContinuation: AsyncStream<RemoteConnectedViewEvents>.Continuation
+    let remoteConnectedViewStream: AsyncStream<RemoteConnectedViewEvents>
 
     /// 촬영 완료 이동 콜백 (리모트 기기)
     var navigateToRemoteCompleteCallBack: (() -> Void)?
 
-    /// 홈 화면으로 이동 (리모트 기기)
-    var navigateToHomeCallback: (() -> Void)?
 
     /// 카메라 기기에게 보내는 명령
     enum CameraDeviceCommand: String {
@@ -105,6 +103,7 @@ final class Advertiser: NSObject {
         )
         (advertisingStream, advertisingContinuation) = AsyncStream.makeStream(of: AdvertiserEvents.self)
         (modeSelectionStream, modeSelectionContinuation) = AsyncStream.makeStream(of: ModeSelectionEvents.self)
+        (remoteConnectedViewStream, remoteConnectedViewContinuation) = AsyncStream.makeStream(of: RemoteConnectedViewEvents.self)
 
         super.init()
         advertiser.delegate = self
@@ -210,19 +209,13 @@ final class Advertiser: NSObject {
         case .navigateToRemoteConnected:
             advertisingContinuation.yield(.navigateToRemoteConnected)
         case .navigateToRemoteCapture:
-            guard let navigateToRemoteCaptureCallBack else { return }
-            DispatchQueue.main.async {
-                navigateToRemoteCaptureCallBack()
-            }
+            remoteConnectedViewContinuation.yield(.navigateToRemoteCapture)
         case .navigateToRemoteComplete:
             DispatchQueue.main.async {
                 self.navigateToRemoteCompleteCallBack?()
             }
         case .navigateToHome:
-            guard let navigateToHomeCallback else { return }
-            DispatchQueue.main.async {
-                navigateToHomeCallback()
-            }
+            remoteConnectedViewContinuation.yield(.navigateToHome)
         case .noticeIsRemoteDevice:
             advertiserType = .remote
             heartBeater.start()

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Advertiser.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Advertiser.swift
@@ -185,7 +185,7 @@ final class Advertiser: NSObject {
         case .switchSelectModeView:
             modeSelectionContinuation.yield(.switchModeSelectionView)
         case .allPhotosStored:
-            streamingStoreContinuation.yield(.onAllPhotosStored)
+            streamingStoreContinuation.yield(.onStoreAllPhotos)
         case .onUpdateCaptureCount:
             streamingStoreContinuation.yield(.onUpdateCaptureCount)
         case .heartBeat:

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Advertiser.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Advertiser.swift
@@ -54,9 +54,6 @@ final class Advertiser: NSObject {
         case stopHeartBeat // heartbeat 종료
     }
 
-    /// 10장 모두 저장 완료 콜백 (촬영기기에서 전송)
-    var onAllPhotosStored: (() -> Void)?
-
     /// heartbeat 메시지 타임아웃
     var onHeartBeatTimeout: (() -> Void)?
 
@@ -190,9 +187,7 @@ final class Advertiser: NSObject {
         case .switchSelectModeView:
             modeSelectionContinuation.yield(.switchModeSelectionView)
         case .allPhotosStored:
-            DispatchQueue.main.async {
-                self.onAllPhotosStored?()
-            }
+            streamingStoreContinuation.yield(.onAllPhotosStored)
         case .onUpdateCaptureCount:
             streamingStoreContinuation.yield(.onUpdateCaptureCount)
         case .heartBeat:

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Advertiser.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Advertiser.swift
@@ -28,8 +28,8 @@ final class Advertiser: NSObject {
     private let videoContinuation: AsyncStream<FrameReceivingEvents>.Continuation
     let videoStream: AsyncStream<FrameReceivingEvents>
 
-    /// 연결 성공 콜백
-    var onConnected: (() -> Void)?
+    private let controlContinuation: AsyncStream<AdvertiserEvents>.Continuation
+    let controlStream: AsyncStream<AdvertiserEvents>
 
     /// 촬영 선택 모드 이동 콜백 (미러링 기기)
     var navigateToSelectModeCommandCallBack: ((_ isRemoteEnable: Bool) -> Void)?
@@ -108,6 +108,10 @@ final class Advertiser: NSObject {
         (videoStream, videoContinuation) = AsyncStream.makeStream(
             of: FrameReceivingEvents.self,
             bufferingPolicy: .bufferingNewest(1)
+        )
+        (controlStream, controlContinuation) = AsyncStream.makeStream(
+            of: AdvertiserEvents.self,
+            bufferingPolicy: .unbounded
         )
 
         super.init()
@@ -256,9 +260,7 @@ extension Advertiser: MCSessionDelegate {
         }
         if session === self.commandSession {
             if state == .connected {
-                DispatchQueue.main.async {
-                    self.onConnected?()
-                }
+                controlContinuation.yield(.onConnected)
             }
         }
     }

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Advertiser.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Advertiser.swift
@@ -37,9 +37,8 @@ final class Advertiser: NSObject {
     private let remoteConnectedViewContinuation: AsyncStream<RemoteConnectedViewEvents>.Continuation
     let remoteConnectedViewStream: AsyncStream<RemoteConnectedViewEvents>
 
-    /// 촬영 완료 이동 콜백 (리모트 기기)
-    var navigateToRemoteCompleteCallBack: (() -> Void)?
-
+    private let remoteCaptureViewContinuation: AsyncStream<RemoteCaptureViewEvents>.Continuation
+    let remoteCaptureViewStream: AsyncStream<RemoteCaptureViewEvents>
 
     /// 카메라 기기에게 보내는 명령
     enum CameraDeviceCommand: String {
@@ -103,7 +102,12 @@ final class Advertiser: NSObject {
         )
         (advertisingStream, advertisingContinuation) = AsyncStream.makeStream(of: AdvertiserEvents.self)
         (modeSelectionStream, modeSelectionContinuation) = AsyncStream.makeStream(of: ModeSelectionEvents.self)
-        (remoteConnectedViewStream, remoteConnectedViewContinuation) = AsyncStream.makeStream(of: RemoteConnectedViewEvents.self)
+        (remoteConnectedViewStream, remoteConnectedViewContinuation) = AsyncStream.makeStream(
+            of: RemoteConnectedViewEvents.self
+        )
+        (remoteCaptureViewStream, remoteCaptureViewContinuation) = AsyncStream.makeStream(
+            of: RemoteCaptureViewEvents.self
+        )
 
         super.init()
         advertiser.delegate = self
@@ -211,9 +215,7 @@ final class Advertiser: NSObject {
         case .navigateToRemoteCapture:
             remoteConnectedViewContinuation.yield(.navigateToRemoteCapture)
         case .navigateToRemoteComplete:
-            DispatchQueue.main.async {
-                self.navigateToRemoteCompleteCallBack?()
-            }
+            remoteCaptureViewContinuation.yield(.navigateToRemoteComplete)
         case .navigateToHome:
             remoteConnectedViewContinuation.yield(.navigateToHome)
         case .noticeIsRemoteDevice:

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Advertiser.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Advertiser.swift
@@ -57,9 +57,6 @@ final class Advertiser: NSObject {
     /// heartbeat 메시지 타임아웃
     var onHeartBeatTimeout: (() -> Void)?
 
-    /// captureEffect 명령 수신 콜백
-    var onCaptureEffect: (() -> Void)?
-
     init(serviceType: String = "mirroringbooth", photoCacheManager: PhotoCacheManager) {
         self.serviceType = serviceType
         self.myDeviceName = PeerNameGenerator.makeDisplayName(isRandom: true, with: UIDevice.current.deviceType)
@@ -193,9 +190,7 @@ final class Advertiser: NSObject {
         case .heartBeat:
             heartBeater.beat()
         case .captureEffect:
-            DispatchQueue.main.async {
-                self.onCaptureEffect?()
-            }
+            streamingStoreContinuation.yield(.onCaptureEffect)
         }
     }
 

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Advertiser.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Advertiser.swift
@@ -28,8 +28,11 @@ final class Advertiser: NSObject {
     private let videoContinuation: AsyncStream<FrameReceivingEvents>.Continuation
     let videoStream: AsyncStream<FrameReceivingEvents>
 
-    private let controlContinuation: AsyncStream<AdvertiserEvents>.Continuation
-    let controlStream: AsyncStream<AdvertiserEvents>
+    private let advertisingContinuation: AsyncStream<AdvertiserEvents>.Continuation
+    let advertisingStream: AsyncStream<AdvertiserEvents>
+
+    private let modeSelectionContinuation: AsyncStream<ModeSelectionEvents>.Continuation
+    let modeSelectionStream: AsyncStream<ModeSelectionEvents>
 
     /// 촬영 화면 이동 콜백 (리모트 기기)
     var navigateToRemoteCaptureCallBack: (() -> Void)?
@@ -50,9 +53,6 @@ final class Advertiser: NSObject {
         case remoteHeartBeat // 리모트 세션 확인용
         case stopHeartBeat // heartbeat 종료
     }
-
-    /// 리모트 기기 연결 끊겼을 때 모드 선택 화면 교체 콜백
-    var switchModeSelectionView: (() -> Void)?
 
     /// 사진 수신 완료 콜백 (1장마다 호출)
     var onPhotoReceived: (() -> Void)?
@@ -103,10 +103,8 @@ final class Advertiser: NSObject {
             of: FrameReceivingEvents.self,
             bufferingPolicy: .bufferingNewest(1)
         )
-        (controlStream, controlContinuation) = AsyncStream.makeStream(
-            of: AdvertiserEvents.self,
-            bufferingPolicy: .unbounded
-        )
+        (advertisingStream, advertisingContinuation) = AsyncStream.makeStream(of: AdvertiserEvents.self)
+        (modeSelectionStream, modeSelectionContinuation) = AsyncStream.makeStream(of: ModeSelectionEvents.self)
 
         super.init()
         advertiser.delegate = self
@@ -185,13 +183,11 @@ final class Advertiser: NSObject {
     private func handleMirroringDeviceCommand(_ mirroringDeviceCommand: Browser.MirroringDeviceCommand) {
         switch mirroringDeviceCommand {
         case .navigateToSelectModeWithRemote:
-            controlContinuation.yield(.navigateToSelectModeCommandCallBack(true))
+            advertisingContinuation.yield(.navigateToSelectModeCommand(true))
         case .navigateToSelectModeWithoutRemote:
-            controlContinuation.yield(.navigateToSelectModeCommandCallBack(false))
+            advertisingContinuation.yield(.navigateToSelectModeCommand(false))
         case .switchSelectModeView:
-            DispatchQueue.main.async {
-                self.switchModeSelectionView?()
-            }
+            modeSelectionContinuation.yield(.switchModeSelectionView)
         case .allPhotosStored:
             DispatchQueue.main.async {
                 self.onAllPhotosStored?()
@@ -212,7 +208,7 @@ final class Advertiser: NSObject {
     private func handleRemoteDeviceCommand(_ remoteDeviceCommand: Browser.RemoteDeviceCommand) {
         switch remoteDeviceCommand {
         case .navigateToRemoteConnected:
-            controlContinuation.yield(.navigateToRemoteConnectedCallBack)
+            advertisingContinuation.yield(.navigateToRemoteConnected)
         case .navigateToRemoteCapture:
             guard let navigateToRemoteCaptureCallBack else { return }
             DispatchQueue.main.async {
@@ -245,7 +241,7 @@ extension Advertiser: MCSessionDelegate {
         }
         if session === self.commandSession {
             if state == .connected {
-                controlContinuation.yield(.onConnected)
+                advertisingContinuation.yield(.onConnected)
             }
         }
     }

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Advertiser.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Advertiser.swift
@@ -31,9 +31,6 @@ final class Advertiser: NSObject {
     private let controlContinuation: AsyncStream<AdvertiserEvents>.Continuation
     let controlStream: AsyncStream<AdvertiserEvents>
 
-    /// 촬영 대기 화면 이동 콜백 (리모트 기기)
-    var navigateToRemoteConnectedCallBack: (() -> Void)?
-
     /// 촬영 화면 이동 콜백 (리모트 기기)
     var navigateToRemoteCaptureCallBack: (() -> Void)?
 
@@ -215,10 +212,7 @@ final class Advertiser: NSObject {
     private func handleRemoteDeviceCommand(_ remoteDeviceCommand: Browser.RemoteDeviceCommand) {
         switch remoteDeviceCommand {
         case .navigateToRemoteConnected:
-            guard let navigateToRemoteConnectedCallBack else { return }
-            DispatchQueue.main.async {
-                navigateToRemoteConnectedCallBack()
-            }
+            controlContinuation.yield(.navigateToRemoteConnectedCallBack)
         case .navigateToRemoteCapture:
             guard let navigateToRemoteCaptureCallBack else { return }
             DispatchQueue.main.async {

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Advertiser.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Advertiser.swift
@@ -43,6 +43,9 @@ final class Advertiser: NSObject {
     private let streamingStoreContinuation: AsyncStream<StreamingStoreEvents>.Continuation
     let streamingStoreStream: AsyncStream<StreamingStoreEvents>
 
+    let rootContinuation: AsyncStream<RootEvents>.Continuation
+    let rootStream: AsyncStream<RootEvents>
+
     /// 카메라 기기에게 보내는 명령
     enum CameraDeviceCommand: String {
         case capturePhoto  // 사진 촬영
@@ -53,9 +56,6 @@ final class Advertiser: NSObject {
         case remoteHeartBeat // 리모트 세션 확인용
         case stopHeartBeat // heartbeat 종료
     }
-
-    /// heartbeat 메시지 타임아웃
-    var onHeartBeatTimeout: (() -> Void)?
 
     init(serviceType: String = "mirroringbooth", photoCacheManager: PhotoCacheManager) {
         self.serviceType = serviceType
@@ -100,6 +100,7 @@ final class Advertiser: NSObject {
             of: RemoteCaptureViewEvents.self
         )
         (streamingStoreStream, streamingStoreContinuation) = AsyncStream.makeStream(of: StreamingStoreEvents.self)
+        (rootStream, rootContinuation) = AsyncStream.makeStream(of: RootEvents.self)
 
         super.init()
         advertiser.delegate = self

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Advertiser.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Advertiser.swift
@@ -31,9 +31,6 @@ final class Advertiser: NSObject {
     private let controlContinuation: AsyncStream<AdvertiserEvents>.Continuation
     let controlStream: AsyncStream<AdvertiserEvents>
 
-    /// 촬영 선택 모드 이동 콜백 (미러링 기기)
-    var navigateToSelectModeCommandCallBack: ((_ isRemoteEnable: Bool) -> Void)?
-
     /// 촬영 대기 화면 이동 콜백 (리모트 기기)
     var navigateToRemoteConnectedCallBack: (() -> Void)?
 
@@ -191,15 +188,9 @@ final class Advertiser: NSObject {
     private func handleMirroringDeviceCommand(_ mirroringDeviceCommand: Browser.MirroringDeviceCommand) {
         switch mirroringDeviceCommand {
         case .navigateToSelectModeWithRemote:
-            guard let navigateToSelectModeCommandCallBack else { return }
-            DispatchQueue.main.async {
-                navigateToSelectModeCommandCallBack(true)
-            }
+            controlContinuation.yield(.navigateToSelectModeCommandCallBack(true))
         case .navigateToSelectModeWithoutRemote:
-            guard let navigateToSelectModeCommandCallBack else { return }
-            DispatchQueue.main.async {
-                navigateToSelectModeCommandCallBack(false)
-            }
+            controlContinuation.yield(.navigateToSelectModeCommandCallBack(false))
         case .switchSelectModeView:
             DispatchQueue.main.async {
                 self.switchModeSelectionView?()

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertiserEvents.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertiserEvents.swift
@@ -14,11 +14,19 @@ enum AdvertiserEvents {
     case navigateToSelectModeCommand(_ isRemoteEnable: Bool)
     /// 촬영 대기 화면 이동 (리모트 기기)
     case navigateToRemoteConnected
+    case navigateToRemoteCapture
 }
 
 enum ModeSelectionEvents {
     /// 리모트 기기 연결 끊겼을 때 모드 선택 화면 교체
     case switchModeSelectionView
+}
+
+enum RemoteConnectedViewEvents {
+    /// 촬영 화면 이동 콜백 (리모트 기기)
+    case navigateToRemoteCapture
+    /// 홈 화면으로 이동 (리모트 기기)
+    case navigateToHome
 }
 
 enum FrameReceivingEvents {

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertiserEvents.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertiserEvents.swift
@@ -39,6 +39,8 @@ enum StreamingStoreEvents {
     case onUpdateCaptureCount
     /// 10장 모두 저장 완료 콜백 (촬영기기에서 전송)
     case onAllPhotosStored
+    /// captureEffect 명령 수신 콜백
+    case onCaptureEffect
 }
 
 enum FrameReceivingEvents {

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertiserEvents.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertiserEvents.swift
@@ -38,7 +38,7 @@ enum StreamingStoreEvents {
     /// 캡쳐 요청 카운트 (촬영기기에서 전송)
     case onUpdateCaptureCount
     /// 10장 저장 시작 (촬영기기에서 전송)
-    case onAllPhotosStored
+    case onStoreAllPhotos
     /// captureEffect 명령 수신 콜백
     case onCaptureEffect
 }

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertiserEvents.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertiserEvents.swift
@@ -11,9 +11,14 @@ enum AdvertiserEvents {
     /// 연결 성공
     case onConnected
     /// 미러링 화면 모드 선택으로 이동(리모트 기기 연결 여부)
-    case navigateToSelectModeCommandCallBack(_ isRemoteEnable: Bool)
+    case navigateToSelectModeCommand(_ isRemoteEnable: Bool)
     /// 촬영 대기 화면 이동 (리모트 기기)
-    case navigateToRemoteConnectedCallBack
+    case navigateToRemoteConnected
+}
+
+enum ModeSelectionEvents {
+    /// 리모트 기기 연결 끊겼을 때 모드 선택 화면 교체
+    case switchModeSelectionView
 }
 
 enum FrameReceivingEvents {

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertiserEvents.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertiserEvents.swift
@@ -9,6 +9,7 @@ import Foundation
 
 enum AdvertiserEvents {
     case onConnected
+    case navigateToSelectModeCommandCallBack(_ isRemoteEnable: Bool)
 }
 
 enum FrameReceivingEvents {

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertiserEvents.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertiserEvents.swift
@@ -43,6 +43,10 @@ enum StreamingStoreEvents {
     case onCaptureEffect
 }
 
+enum RootEvents {
+    case onHeartbeatTimeout
+}
+
 enum FrameReceivingEvents {
     case streamDataReceived(Data)
 }

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertiserEvents.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertiserEvents.swift
@@ -37,6 +37,8 @@ enum StreamingStoreEvents {
     case onPhotoReceived
     /// 캡쳐 요청 카운트 (촬영기기에서 전송)
     case onUpdateCaptureCount
+    /// 10장 모두 저장 완료 콜백 (촬영기기에서 전송)
+    case onAllPhotosStored
 }
 
 enum FrameReceivingEvents {

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertiserEvents.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertiserEvents.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 enum AdvertiserEvents {
-    // TODO: 흐름 제어 이벤트 추가 예정
+    case onConnected
 }
 
 enum FrameReceivingEvents {

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertiserEvents.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertiserEvents.swift
@@ -29,6 +29,10 @@ enum RemoteConnectedViewEvents {
     case navigateToHome
 }
 
+enum RemoteCaptureViewEvents {
+    case navigateToRemoteComplete
+}
+
 enum FrameReceivingEvents {
     case streamDataReceived(Data)
 }

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertiserEvents.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertiserEvents.swift
@@ -33,6 +33,12 @@ enum RemoteCaptureViewEvents {
     case navigateToRemoteComplete
 }
 
+enum StreamingStoreEvents {
+    case onPhotoReceived
+    /// 캡쳐 요청 카운트 (촬영기기에서 전송)
+    case onUpdateCaptureCount
+}
+
 enum FrameReceivingEvents {
     case streamDataReceived(Data)
 }

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertiserEvents.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertiserEvents.swift
@@ -37,7 +37,7 @@ enum StreamingStoreEvents {
     case onPhotoReceived
     /// 캡쳐 요청 카운트 (촬영기기에서 전송)
     case onUpdateCaptureCount
-    /// 10장 모두 저장 완료 콜백 (촬영기기에서 전송)
+    /// 10장 저장 시작 (촬영기기에서 전송)
     case onAllPhotosStored
     /// captureEffect 명령 수신 콜백
     case onCaptureEffect

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertiserEvents.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertiserEvents.swift
@@ -8,8 +8,12 @@
 import Foundation
 
 enum AdvertiserEvents {
+    /// 연결 성공
     case onConnected
+    /// 미러링 화면 모드 선택으로 이동(리모트 기기 연결 여부)
     case navigateToSelectModeCommandCallBack(_ isRemoteEnable: Bool)
+    /// 촬영 대기 화면 이동 (리모트 기기)
+    case navigateToRemoteConnectedCallBack
 }
 
 enum FrameReceivingEvents {

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertisingStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertisingStore.swift
@@ -39,12 +39,6 @@ final class AdvertisingStore: StoreProtocol {
     init(_ advertiser: Advertiser) {
         self.advertiser = advertiser
         subscribeToStream()
-
-        advertiser.navigateToRemoteCaptureCallBack = { [weak self] in
-            Task { @MainActor in
-                self?.reduce(.setOnNavigate(true, type: .remote))
-            }
-        }
     }
 
     func action(_ intent: Intent) -> [Result] {
@@ -104,6 +98,8 @@ extension AdvertisingStore {
                         self.reduce(.setOnNavigate(true, type: .mirroring))
                     }
                 case .navigateToRemoteConnected:
+                    await MainActor.run { self.reduce(.setOnNavigate(true, type: .remote)) }
+                case .navigateToRemoteCapture:
                     await MainActor.run { self.reduce(.setOnNavigate(true, type: .remote)) }
                 }
             }

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertisingStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertisingStore.swift
@@ -94,16 +94,16 @@ extension AdvertisingStore {
     private func subscribeToStream() {
         streamingTask = Task { [weak self] in
             guard let self else { return }
-            for await stream in advertiser.controlStream {
+            for await stream in advertiser.advertisingStream {
                 switch stream {
                 case .onConnected:
                     await MainActor.run { self.send(.connected) }
-                case .navigateToSelectModeCommandCallBack(let isRemoteEnable):
+                case .navigateToSelectModeCommand(let isRemoteEnable):
                     await MainActor.run {
                         self.reduce(.setIsRemoteSelected(isRemoteEnable))
                         self.reduce(.setOnNavigate(true, type: .mirroring))
                     }
-                case .navigateToRemoteConnectedCallBack:
+                case .navigateToRemoteConnected:
                     await MainActor.run { self.reduce(.setOnNavigate(true, type: .remote)) }
                 }
             }

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertisingStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertisingStore.swift
@@ -86,21 +86,19 @@ final class AdvertisingStore: StoreProtocol {
 // MARK: Stream 구독
 extension AdvertisingStore {
     private func subscribeToStream() {
-        commandTask = Task { [weak self] in
+        commandTask = Task { @MainActor [weak self] in
             guard let self else { return }
             for await stream in advertiser.advertisingStream {
                 switch stream {
                 case .onConnected:
-                    await MainActor.run { self.send(.connected) }
+                    self.send(.connected)
                 case .navigateToSelectModeCommand(let isRemoteEnable):
-                    await MainActor.run {
-                        self.reduce(.setIsRemoteSelected(isRemoteEnable))
-                        self.reduce(.setOnNavigate(true, type: .mirroring))
-                    }
+                    self.reduce(.setIsRemoteSelected(isRemoteEnable))
+                    self.reduce(.setOnNavigate(true, type: .mirroring))
                 case .navigateToRemoteConnected:
-                    await MainActor.run { self.reduce(.setOnNavigate(true, type: .remote)) }
+                    self.reduce(.setOnNavigate(true, type: .remote))
                 case .navigateToRemoteCapture:
-                    await MainActor.run { self.reduce(.setOnNavigate(true, type: .remote)) }
+                    self.reduce(.setOnNavigate(true, type: .remote))
                 }
             }
         }

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertisingStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertisingStore.swift
@@ -34,15 +34,10 @@ final class AdvertisingStore: StoreProtocol {
 
     var state: State = .init()
     let advertiser: Advertiser
+    private var streamingTask: Task<Void, Never>?
 
     init(_ advertiser: Advertiser) {
         self.advertiser = advertiser
-
-        advertiser.onConnected = { [weak self] in
-            Task { @MainActor in
-                self?.send(.connected)
-            }
-        }
 
         advertiser.navigateToSelectModeCommandCallBack = { [weak self] isRemoteEnable in
             Task { @MainActor in
@@ -103,4 +98,20 @@ final class AdvertisingStore: StoreProtocol {
         self.state = state
     }
 
+}
+
+// MARK: Stream 구독
+extension AdvertisingStore {
+    private func subscribeToStream() {
+        streamingTask = Task { [weak self] in
+            guard let self else { return }
+            for await stream in advertiser.controlStream {
+                if case .onConnected = stream {
+                    await MainActor.run {
+                        self.send(.connected)
+                    }
+                }
+            }
+        }
+    }
 }

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertisingStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertisingStore.swift
@@ -39,13 +39,6 @@ final class AdvertisingStore: StoreProtocol {
     init(_ advertiser: Advertiser) {
         self.advertiser = advertiser
 
-        advertiser.navigateToSelectModeCommandCallBack = { [weak self] isRemoteEnable in
-            Task { @MainActor in
-                self?.reduce(.setIsRemoteSelected(isRemoteEnable))
-                self?.reduce(.setOnNavigate(true, type: .mirroring))
-            }
-        }
-
         advertiser.navigateToRemoteConnectedCallBack = { [weak self] in
             Task { @MainActor in
                 self?.reduce(.setOnNavigate(true, type: .remote))
@@ -106,9 +99,13 @@ extension AdvertisingStore {
         streamingTask = Task { [weak self] in
             guard let self else { return }
             for await stream in advertiser.controlStream {
-                if case .onConnected = stream {
+                switch stream {
+                case .onConnected:
+                    await MainActor.run { self.send(.connected) }
+                case .navigateToSelectModeCommandCallBack(let isRemoteEnable):
                     await MainActor.run {
-                        self.send(.connected)
+                        self.reduce(.setIsRemoteSelected(isRemoteEnable))
+                        self.reduce(.setOnNavigate(true, type: .mirroring))
                     }
                 }
             }

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertisingStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertisingStore.swift
@@ -40,12 +40,6 @@ final class AdvertisingStore: StoreProtocol {
         self.advertiser = advertiser
         subscribeToStream()
 
-        advertiser.navigateToRemoteConnectedCallBack = { [weak self] in
-            Task { @MainActor in
-                self?.reduce(.setOnNavigate(true, type: .remote))
-            }
-        }
-
         advertiser.navigateToRemoteCaptureCallBack = { [weak self] in
             Task { @MainActor in
                 self?.reduce(.setOnNavigate(true, type: .remote))
@@ -109,6 +103,8 @@ extension AdvertisingStore {
                         self.reduce(.setIsRemoteSelected(isRemoteEnable))
                         self.reduce(.setOnNavigate(true, type: .mirroring))
                     }
+                case .navigateToRemoteConnectedCallBack:
+                    await MainActor.run { self.reduce(.setOnNavigate(true, type: .remote)) }
                 }
             }
         }

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertisingStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertisingStore.swift
@@ -38,6 +38,7 @@ final class AdvertisingStore: StoreProtocol {
 
     init(_ advertiser: Advertiser) {
         self.advertiser = advertiser
+        subscribeToStream()
 
         advertiser.navigateToRemoteConnectedCallBack = { [weak self] in
             Task { @MainActor in
@@ -63,6 +64,7 @@ final class AdvertisingStore: StoreProtocol {
             return [.setIsConnected(true)]
 
         case .exit:
+            streamingTask?.cancel()
             advertiser.stopSearching()
             return []
 

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertisingStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertisingStore.swift
@@ -34,7 +34,7 @@ final class AdvertisingStore: StoreProtocol {
 
     var state: State = .init()
     let advertiser: Advertiser
-    private var streamingTask: Task<Void, Never>?
+    private var commandTask: Task<Void, Never>?
 
     init(_ advertiser: Advertiser) {
         self.advertiser = advertiser
@@ -52,7 +52,7 @@ final class AdvertisingStore: StoreProtocol {
             return [.setIsConnected(true)]
 
         case .exit:
-            streamingTask?.cancel()
+            commandTask?.cancel()
             advertiser.stopSearching()
             return []
 
@@ -86,7 +86,7 @@ final class AdvertisingStore: StoreProtocol {
 // MARK: Stream 구독
 extension AdvertisingStore {
     private func subscribeToStream() {
-        streamingTask = Task { [weak self] in
+        commandTask = Task { [weak self] in
             guard let self else { return }
             for await stream in advertiser.advertisingStream {
                 switch stream {

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertisingView.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertisingView.swift
@@ -66,31 +66,23 @@ struct AdvertisingView: View {
         .onDisappear {
             store.send(.exit)
         }
+        .task {
+            for await stream in store.advertiser.remoteConnectedViewStream {
+                switch stream {
+                case .navigateToRemoteCapture:
+                    router.push(to: RemoteRoute.remoteCapture(store.advertiser))
+                case .navigateToHome:
+                    router.reset()
+                }
+            }
+        }
         .onChange(of: store.state.onNavigate) { _, newValue in
             if newValue {
                 guard let deviceUseType = store.state.deviceUseType else { return }
-
-                switch deviceUseType {
-                case .mirroring:
+                if case .mirroring = deviceUseType {
                     router.push(
                         to: MirroringRoute.timerOrRemoteSelection(isRemoteEnable: store.state.isRemoteSelected)
                     )
-                case .remote:
-                    // 리모트 모드 선택 시 촬영 뷰로 이동
-                    store.advertiser.navigateToRemoteCaptureCallBack = { [weak router] in
-                        guard let router else { return }
-                        DispatchQueue.main.async {
-                            router.push(to: RemoteRoute.remoteCapture(store.advertiser))
-                        }
-                    }
-
-                    // 타이머 모드 선택 시 처음 화면으로 이동
-                    store.advertiser.navigateToHomeCallback = { [weak router] in
-                        guard let router else { return }
-                        DispatchQueue.main.async {
-                            router.reset()
-                        }
-                    }
                 }
             }
         }

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertisingView.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertisingView.swift
@@ -56,12 +56,7 @@ struct AdvertisingView: View {
         }
         .onAppear {
             store.send(.onAppear)
-            if rootStore.advertiser == nil {
-                rootStore.advertiser = store.advertiser
-            }
-            store.advertiser.onHeartBeatTimeout = { [weak rootStore] in
-                rootStore?.send(.showTimeoutAlert(true))
-            }
+            rootStore.advertiser = store.advertiser
         }
         .onDisappear {
             store.send(.exit)

--- a/mirroringBooth/mirroringBoothTests/AdvertiserTests.swift
+++ b/mirroringBooth/mirroringBoothTests/AdvertiserTests.swift
@@ -242,7 +242,7 @@ final class AdvertiserTests: XCTestCase {
         let streamTask = Task {
             for await event in await advertiser.streamingStoreStream {
                 switch event {
-                case .onAllPhotosStored: expectationAllStored.fulfill()
+                case .onStoreAllPhotos: expectationAllStored.fulfill()
                 case .onUpdateCaptureCount: expectationUpdateCount.fulfill()
                 case .onCaptureEffect: expectationCaptureEffect.fulfill()
                 case .onPhotoReceived: expectationPhotoReceived.fulfill()

--- a/mirroringBooth/mirroringBoothTests/AdvertiserTests.swift
+++ b/mirroringBooth/mirroringBoothTests/AdvertiserTests.swift
@@ -1,63 +1,318 @@
 //
 //  AdvertiserTests.swift
-//  mirroringBooth
+//  mirroringBoothTests
 //
 //  Created by Liam on 2/2/26.
 //
 
-import XCTest
 import MultipeerConnectivity
+import XCTest
 @testable import mirroringBooth
 
 // AI 보조로 작성
 final class AdvertiserTests: XCTestCase {
     var advertiser: Advertiser!
-    var mockCacheManager: PhotoCacheManager!
+    var cacheManager: PhotoCacheManager!
 
     override func setUp() async throws {
-        mockCacheManager = PhotoCacheManager.shared
-        await mockCacheManager.startNewSession()
-        advertiser = await Advertiser(photoCacheManager: mockCacheManager)
+        cacheManager = PhotoCacheManager.shared
+        await cacheManager.startNewSession()
+        advertiser = await Advertiser(photoCacheManager: cacheManager)
     }
 
     override func tearDown() async throws {
         await advertiser.disconnect()
         advertiser = nil
-        await mockCacheManager.clearCache()
-        mockCacheManager = nil
+        await cacheManager.clearCache()
+        cacheManager = nil
     }
 
-    func testVideoStreamYieldsDataWhenReceived() async throws {
-        // GIVEN: Session이 설정되고 스트림 구독이 준비됨
+    // MARK: - Video Stream Tests
+
+    func test비디오스트림_데이터수신시_정상_전달() async throws {
+        // GIVEN
         let testData = "testData".data(using: .utf8)!
         let peerID = MCPeerID(displayName: "TestPeer")
-        let session = try await setupStreamingSession(with: peerID)
+        let session = try setupStreamingSession(with: peerID)
 
-        var receivedData: Data?
+        let expectation = expectation(description: "비디오 데이터 수신 대기")
+
         let streamTask = Task {
             for await event in await advertiser.videoStream {
                 if case .streamDataReceived(let data) = event {
-                    receivedData = data
-                    break
+                    if data == testData {
+                        expectation.fulfill()
+                    }
                 }
             }
         }
         defer { streamTask.cancel() }
 
-        // 구독 준비 시간
-        try await Task.sleep(nanoseconds: 50_000_000)
-
-        // WHEN: 데이터를 수신함
+        // WHEN
         await advertiser.session(session, didReceive: testData, fromPeer: peerID)
 
-        // THEN: videoStream을 통해 해당 데이터가 전달됨
-        try await Task.sleep(nanoseconds: 100_000_000)
-        XCTAssertEqual(receivedData, testData, "Received data should match sent data")
+        // THEN
+        await fulfillment(of: [expectation], timeout: 1.0)
     }
 
-    // Helper method
-    private func setupStreamingSession(with peerID: MCPeerID) async throws -> MCSession {
-        let context = Browser.SessionType.streaming.rawValue.data(using: .utf8)
+    // MARK: - Advertising Stream Tests
+
+    func test광고스트림_연결성공_이벤트_전달() async throws {
+        // GIVEN
+        let expectation = expectation(description: "연결 성공 이벤트 대기")
+        let peerID = MCPeerID(displayName: "CommandPeer")
+        let session = try setupCommandSession(with: peerID)
+
+        let streamTask = Task {
+            for await event in await advertiser.advertisingStream {
+                if case .onConnected = event {
+                    expectation.fulfill()
+                }
+            }
+        }
+        defer { streamTask.cancel() }
+
+
+        // WHEN: 명령 세션이 연결됨
+        await advertiser.session(session, peer: peerID, didChange: .connected)
+
+        // THEN
+        await fulfillment(of: [expectation], timeout: 1.0)
+    }
+
+    func test광고스트림_모드선택_명령_전달() async throws {
+        // GIVEN
+        let expectationWithRemote = expectation(description: "원격 포함 모드 선택 명령 대기")
+        let expectationWithoutRemote = expectation(description: "원격 미포함 모드 선택 명령 대기")
+
+        let peerID = MCPeerID(displayName: "CommandPeer")
+        let session = try setupCommandSession(with: peerID)
+
+        let streamTask = Task {
+            for await event in await advertiser.advertisingStream {
+                switch event {
+                case .navigateToSelectModeCommand(let isRemote):
+                    if isRemote {
+                        expectationWithRemote.fulfill()
+                    } else {
+                        expectationWithoutRemote.fulfill()
+                    }
+                default: break
+                }
+            }
+        }
+        defer { streamTask.cancel() }
+
+
+        // WHEN: 원격 포함 명령 수신
+        let commandWithRemote = Browser.MirroringDeviceCommand.navigateToSelectModeWithRemote.rawValue.data(using: .utf8)!
+        await advertiser.session(session, didReceive: commandWithRemote, fromPeer: peerID)
+
+        // WHEN: 원격 미포함 명령 수신
+        let commandWithoutRemote = Browser.MirroringDeviceCommand.navigateToSelectModeWithoutRemote.rawValue.data(using: .utf8)!
+        await advertiser.session(session, didReceive: commandWithoutRemote, fromPeer: peerID)
+
+        // THEN
+        await fulfillment(of: [expectationWithRemote, expectationWithoutRemote], timeout: 1.0)
+    }
+
+    func test광고스트림_리모트연결_명령_전달() async throws {
+        // GIVEN
+        let expectation = expectation(description: "리모트 연결 명령 대기")
+        let peerID = MCPeerID(displayName: "CommandPeer")
+        let session = try setupCommandSession(with: peerID)
+
+        let streamTask = Task {
+            for await event in await advertiser.advertisingStream {
+                if case .navigateToRemoteConnected = event {
+                    expectation.fulfill()
+                }
+            }
+        }
+        defer { streamTask.cancel() }
+
+
+        // WHEN
+        let command = Browser.RemoteDeviceCommand.navigateToRemoteConnected.rawValue.data(using: .utf8)!
+        await advertiser.session(session, didReceive: command, fromPeer: peerID)
+
+        // THEN
+        await fulfillment(of: [expectation], timeout: 1.0)
+    }
+
+    // MARK: - Mode Selection Stream Tests
+
+    func test모드선택스트림_모드선택뷰_전환_명령_전달() async throws {
+        // GIVEN
+        let expectation = expectation(description: "모드 선택 뷰 전환 명령 대기")
+        let peerID = MCPeerID(displayName: "CommandPeer")
+        let session = try setupCommandSession(with: peerID)
+
+        let streamTask = Task {
+            for await event in await advertiser.modeSelectionStream {
+                if case .switchModeSelectionView = event {
+                    expectation.fulfill()
+                }
+            }
+        }
+        defer { streamTask.cancel() }
+
+
+        // WHEN
+        let command = Browser.MirroringDeviceCommand.switchSelectModeView.rawValue.data(using: .utf8)!
+        await advertiser.session(session, didReceive: command, fromPeer: peerID)
+
+        // THEN
+        await fulfillment(of: [expectation], timeout: 1.0)
+    }
+
+    // MARK: - Remote Connected View Stream Tests
+
+    func test리모트연결뷰스트림_이벤트_전달() async throws {
+        // GIVEN
+        let expectationCapture = expectation(description: "리모트 촬영 이동 명령 대기")
+        let expectationHome = expectation(description: "홈 화면 이동 명령 대기")
+
+        let peerID = MCPeerID(displayName: "CommandPeer")
+        let session = try setupCommandSession(with: peerID)
+
+        let streamTask = Task {
+            for await event in await advertiser.remoteConnectedViewStream {
+                switch event {
+                case .navigateToRemoteCapture:
+                    expectationCapture.fulfill()
+                case .navigateToHome:
+                    expectationHome.fulfill()
+                }
+            }
+        }
+        defer { streamTask.cancel() }
+
+
+        // WHEN: Capture 명령
+        let commandCapture = Browser.RemoteDeviceCommand.navigateToRemoteCapture.rawValue.data(using: .utf8)!
+        await advertiser.session(session, didReceive: commandCapture, fromPeer: peerID)
+
+        // WHEN: Home 명령
+        let commandHome = Browser.RemoteDeviceCommand.navigateToHome.rawValue.data(using: .utf8)!
+        await advertiser.session(session, didReceive: commandHome, fromPeer: peerID)
+
+        // THEN
+        await fulfillment(of: [expectationCapture, expectationHome], timeout: 1.0)
+    }
+
+    // MARK: - Remote Capture View Stream Tests
+
+    func test리모트촬영뷰스트림_리모트완료_명령_전달() async throws {
+        // GIVEN
+        let expectation = expectation(description: "리모트 완료 명령 대기")
+        let peerID = MCPeerID(displayName: "CommandPeer")
+        let session = try setupCommandSession(with: peerID)
+
+        let streamTask = Task {
+            for await event in await advertiser.remoteCaptureViewStream {
+                if case .navigateToRemoteComplete = event {
+                    expectation.fulfill()
+                }
+            }
+        }
+        defer { streamTask.cancel() }
+
+
+        // WHEN
+        let command = Browser.RemoteDeviceCommand.navigateToRemoteComplete.rawValue.data(using: .utf8)!
+        await advertiser.session(session, didReceive: command, fromPeer: peerID)
+
+        // THEN
+        await fulfillment(of: [expectation], timeout: 1.0)
+    }
+
+    // MARK: - Streaming Store Stream Tests
+
+    func test스트리밍스토어스트림_이벤트_전달() async throws {
+        // GIVEN
+        let expectationAllStored = expectation(description: "모든 사진 저장 완료 대기")
+        let expectationUpdateCount = expectation(description: "촬영 횟수 업데이트 대기")
+        let expectationCaptureEffect = expectation(description: "캡처 효과 명령 대기")
+        let expectationPhotoReceived = expectation(description: "사진 수신 완료 대기")
+
+        let peerID = MCPeerID(displayName: "CommandPeer")
+        let session = try setupCommandSession(with: peerID)
+
+        let streamTask = Task {
+            for await event in await advertiser.streamingStoreStream {
+                switch event {
+                case .onAllPhotosStored: expectationAllStored.fulfill()
+                case .onUpdateCaptureCount: expectationUpdateCount.fulfill()
+                case .onCaptureEffect: expectationCaptureEffect.fulfill()
+                case .onPhotoReceived: expectationPhotoReceived.fulfill()
+                }
+            }
+        }
+        defer { streamTask.cancel() }
+
+
+        // WHEN
+        let commandAllStored = Browser.MirroringDeviceCommand.allPhotosStored.rawValue.data(using: .utf8)!
+        await advertiser.session(session, didReceive: commandAllStored, fromPeer: peerID)
+
+        let commandUpdateCount = Browser.MirroringDeviceCommand.onUpdateCaptureCount.rawValue.data(using: .utf8)!
+        await advertiser.session(session, didReceive: commandUpdateCount, fromPeer: peerID)
+
+        let commandCaptureEffect = Browser.MirroringDeviceCommand.captureEffect.rawValue.data(using: .utf8)!
+        await advertiser.session(session, didReceive: commandCaptureEffect, fromPeer: peerID)
+
+        // 사진 수신 시뮬레이션 (didFinishReceivingResource)
+        // 파일이 없으면 에러가 날 수 있으므로 임시 파일 생성
+        let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent("test_photo.jpg")
+        try "dummy data".data(using: .utf8)?.write(to: tempURL)
+
+        // streaming session이 아닌 command session으로 사진이 오진 않겠지만, delegate 메서드 호출 테스트이므로 세션 객체 전달
+        await advertiser.session(session, didFinishReceivingResourceWithName: "test", fromPeer: peerID, at: tempURL, withError: nil)
+
+        // THEN
+        await fulfillment(of: [expectationAllStored, expectationUpdateCount, expectationCaptureEffect, expectationPhotoReceived], timeout: 2.0)
+    }
+
+    // MARK: - Root Stream Tests (Timeout)
+
+    func test루트스트림_하트비트_타임아웃_이벤트_전달() async throws {
+        // GIVEN
+        let expectation = expectation(description: "하트비트 타임아웃 이벤트 대기")
+
+        // HeartBeaterDelegate.onTimeout을 직접 호출하기 어려우므로,
+        // Advertiser가 HeartBeaterDelegate를 채택하고 있으므로 직접 onTimeout을 호출하여 테스트
+        // (단, onTimeout이 public이 아니거나 internal이면 테스트 타겟에서 접근 가능해야 함)
+        // 여기서는 HeartBeater를 모킹하거나, private 메서드를 호출할 수 없으므로
+        // HeartBeaterDelegate의 메서드가 internal이라고 가정하고 호출.
+        // 만약 접근 불가하다면, HeartBeater 동작(시간 경과)을 기다려야 하는데 시간이 걸림.
+        // 대안: Advertiser+HeartBeater.swift의 onTimeout이 내부적으로 호출하는 로직을 검증해야 함.
+        // 이 테스트 파일이 @testable import를 사용하므로 internal 메서드 접근 가능.
+
+        let streamTask = Task {
+            for await event in await advertiser.rootStream {
+                if case .onHeartbeatTimeout = event {
+                    expectation.fulfill()
+                }
+            }
+        }
+        defer { streamTask.cancel() }
+
+
+        // WHEN
+        // HeartBeater 인스턴스를 직접 조작하기 어려우므로 Delegate 메서드를 직접 호출하여 시뮬레이션
+        // (HeartBeater 객체는 더미로 전달)
+        let dummyHeartBeater = await HeartBeater(repeatInterval: 1, timeout: 1)
+        await advertiser.onTimeout(dummyHeartBeater)
+
+        // THEN
+        await fulfillment(of: [expectation], timeout: 1.0)
+    }
+
+    // MARK: - Helper Methods
+
+    private func setupStreamingSession(with peerID: MCPeerID) throws -> MCSession {
+        let context = "streaming".data(using: .utf8)
         let dummyAdvertiser = MCNearbyServiceAdvertiser(
             peer: peerID,
             discoveryInfo: nil,
@@ -65,20 +320,42 @@ final class AdvertiserTests: XCTestCase {
         )
 
         var capturedSession: MCSession?
-
-        await advertiser.advertiser(
+        advertiser.advertiser(
             dummyAdvertiser,
             didReceiveInvitationFromPeer: peerID,
             withContext: context
         ) { accept, session in
-            XCTAssertTrue(accept, "Should accept streaming invitation")
+            XCTAssertTrue(accept)
             capturedSession = session
         }
 
         guard let session = capturedSession else {
             throw TestError.sessionNotCreated
         }
+        return session
+    }
 
+    private func setupCommandSession(with peerID: MCPeerID) throws -> MCSession {
+        let context = "command".data(using: .utf8)
+        let dummyAdvertiser = MCNearbyServiceAdvertiser(
+            peer: peerID,
+            discoveryInfo: nil,
+            serviceType: "test"
+        )
+
+        var capturedSession: MCSession?
+        advertiser.advertiser(
+            dummyAdvertiser,
+            didReceiveInvitationFromPeer: peerID,
+            withContext: context
+        ) { accept, session in
+            XCTAssertTrue(accept)
+            capturedSession = session
+        }
+
+        guard let session = capturedSession else {
+            throw TestError.sessionNotCreated
+        }
         return session
     }
 


### PR DESCRIPTION
## 🔗 연관된 이슈
- closed #272 

## 📝 작업 내용

### 📌 요약
- advertiser 내에 존재하는 클로저들을 AsyncStream으로 교체
- 발생할 수 있는 이벤트들은 AdvertiserEvents 파일에 위치
- 같은 객체에서 이벤트 받는 단위로 AsyncStream 생성. 
- onHeartBeat클로저는 변경 후 생기는 오류를 잡지 못해 차후 다른 작업에서 개선 예정: 첫 번째 이벤트는 잘 받지만, 두 번째 부터의 이벤트는 받지 못해 heartbeat의 onTimeout 델리게이트가 정상적으로 호출되어도 이벤트가 구독자에게 전달되지 않음.
fix(2026.2.3): 버그 수정

## 💬 리뷰 노트
- 최초 기획할 때는 asyncStream이 이벤트를 소모한다는 것에 집중하여, 여러 구독자가 있어도 그 중 가장 먼저 이벤트를 받은 하나의 구독자만 이벤트를 소모하여 경쟁이 없는 방식이라고 생각했습니다. 반만 맞았던 것이 이벤트를 한 번만 소모하는 것은 맞지만 구독자 여럿을 두고 버스 형태로 관리할 수 없고, 단 일 구독자만 둘 수 있었습니다. 이에 하나의 구독자만 두기 위해 개설한 Stream 하나당 하나의 객체에서 구독을 하였습니다.
- refactor 이후 느껴지는 장점
  -  클로저가 있었던 만큼 continuation, stream 객체를 생성하였지만 이벤트를 발송하는 곳, 수신하는 곳에서 코드가 간결해짐. 
  - 이벤트가 객체별로 묶여 추적이 비교적 용이해짐.
- test는 지난 pr에서 받은 피드백에 따라 모호할 수 있는 MockCacheManger -> CacheManger로 변경하고 AI 돌렸습니다.

- 기존에 존재했던 버그: AdvertisingView에서 Advertiser를 처음 생성하고, 관리를 위해 RootStore에 참조를 넣어주고 있었는데 이 때 nil이 아닐 경우에만 할당하고 있었습니다. 하지만 연결 끊김 등으로 인해 해당 뷰에서 홈 화면으로 돌아갔을 때 Advertiser는 삭제되었다가 재생성되지만 RootStore는 이전에 생성했던 Advertiser에 대한 참조를 유지하고 있기 때문에 새로운 Advertiser에 대한 참조를 넣어주지 않아 버그가 발생했습니다.
해결을 위해 rootStore가 기존에 참조하던 값이 있는지 확인하지 않고 무조건 새로 할당하는 방식으로 변경하였습니다.

## 📸 영상 / 이미지 (Optional)
<img width="302" height="286" alt="image" src="https://github.com/user-attachments/assets/e5bfdf7d-75d9-4bba-9966-7ed50c5a92c3" />
