### PR TITLE
[Refactor/#259] Photo 타입에서 imageData를 제거하고 LocalAsyncImage를 적용한다

### DIFF
--- a/mirroringBooth/mirroringBooth/Device/Mirroring/PhotoComposition/Component/PhotoFramePreview.swift
+++ b/mirroringBooth/mirroringBooth/Device/Mirroring/PhotoComposition/Component/PhotoFramePreview.swift
@@ -13,114 +13,64 @@ struct PhotoFramePreview: View {
     var body: some View {
         GeometryReader { geometry in
             let size = geometry.size
-            ZStack(alignment: .topLeading) {
+
+            Canvas { context, _ in
+                let canvas = CGRect(origin: .zero, size: size)
+
                 // 1. 프레임 (배경)
                 if let frameImage = information.frame.image {
-                    Image(uiImage: frameImage)
-                        .resizable()
-                        .aspectRatio(contentMode: .fill)
+                    let frameTarget = aspectFillRect(for: frameImage.size, into: canvas)
+                    context.draw(Image(uiImage: frameImage), in: frameTarget)
                 }
 
                 // 2. 사진 슬롯들
                 let slots = information.layout.frameRects().map { $0.denormalized(in: size) }
-                ForEach(Array(zip(slots.indices, slots)), id: \.0) { index, slot in
-                    Group {
-                        if index < information.photos.count {
-                            LocalAsyncImage(
-                                url: information.photos[index].url,
-                                slotAspect: slot.width / slot.height
-                            )
+                for (index, slot) in slots.enumerated() {
+                    context.drawLayer { layer in
+                        layer.clip(to: Path(roundedRect: slot, cornerRadius: 5))
+
+                        if index < information.photos.count,
+                           let photoData = information.photos[index].imageData,
+                           let photo = UIImage(data: photoData) {
+                            let target = aspectFillRect(for: photo.size, into: slot)
+                            layer.draw(Image(uiImage: photo), in: target)
                         } else {
-                            RoundedRectangle(cornerRadius: 5)
-                                .fill(information.frame == .white ? .gray : .white)
+                            layer.fill(
+                                Path(roundedRect: slot, cornerRadius: 5),
+                                with: .color(information.frame == .white
+                                             ? .gray
+                                             : .white)
+                            )
                         }
                     }
-                    .frame(width: slot.width, height: slot.height)
-                    .offset( x: slot.minX, y: slot.minY)
                 }
 
                 // 3. 날짜
-                let (backgroundRect, textRect) = dateRects(parentSize: size)
+                let (resolvedText, textSize) = calculateDateViewSize(parentSize: size, with: context)
+                let (backgroundRect, textRect) = dateRects(
+                    parentSize: size,
+                    resolvedText: resolvedText,
+                    textSize: textSize
+                )
 
-                if let backgroundName = information.frame.dateBackgroundName,
-                   let image = UIImage(named: backgroundName) {
-                    let target = aspectFillRect(for: image.size, into: backgroundRect)
-                        .insetBy(
-                            dx: -(textRect.width * 0.35),
-                            dy: -(textRect.height * 0.2)
-                        )
-
-                    Image(uiImage: image)
-                        .resizable()
-                        .frame(width: target.width, height: target.height)
-                        .offset(x: target.minX, y: target.minY)
+                if let backgroundName = information.frame.dateBackgroundName {
+                    if let image = UIImage(named: backgroundName) {
+                        let target = aspectFillRect(for: image.size, into: backgroundRect)
+                            .insetBy(
+                                dx: -(textSize.width * 0.35),
+                                dy: -(textSize.height * 0.2)
+                            )
+                        context.draw(Image(uiImage: image), in: target)
+                    }
                 }
 
-                Text(formattedToday())
-                    .foregroundStyle(information.frame.textColor)
-                    .font(.system(size: dateFontSize(parentSize: size)).bold())
-                    .frame(width: textRect.width, height: textRect.height, alignment: .topLeading)
-                    .offset(x: textRect.minX, y: textRect.minY)
+                context.draw(resolvedText, in: textRect)
             }
         }
         .aspectRatio(information.layout.previewAspect, contentMode: .fit)
-        .clipped()
     }
 
-    private func formattedToday() -> String {
-        Date().formatted(
-            .dateTime.year(.defaultDigits)
-            .month(.twoDigits)
-            .day(.twoDigits)
-        )
-        .replacingOccurrences(of: "-", with: ".")
-    }
-
-    private func dateFontSize(parentSize: CGSize) -> CGFloat {
-        max(parentSize.width, parentSize.height) * 0.03
-    }
-
-    private func measureDateTextSize(parentSize: CGSize) -> CGSize {
-        let text = formattedToday()
-        let font = UIFont.systemFont(
-            ofSize: dateFontSize(parentSize: parentSize),
-            weight: .bold
-        )
-
-        let attributes: [NSAttributedString.Key: Any] = [
-            .font: font
-        ]
-
-        return (text as NSString).size(withAttributes: attributes)
-    }
-
-    private func dateRects(parentSize: CGSize) -> (CGRect, CGRect) {
-        let normalizedOrigin = information.layout.dateOrigin()
-        let dateOrigin = CGPoint(
-            x: normalizedOrigin.x * parentSize.width,
-            y: normalizedOrigin.y * parentSize.height
-        )
-
-        let textSize = measureDateTextSize(parentSize: parentSize)
-
-        let padding: CGFloat = 4
-        let backgroundRect = CGRect(
-            x: dateOrigin.x,
-            y: dateOrigin.y,
-            width: textSize.width + padding * 2,
-            height: textSize.height + padding
-        )
-
-        let textRect = CGRect(
-            x: dateOrigin.x + padding,
-            y: dateOrigin.y + padding / 2,
-            width: textSize.width,
-            height: textSize.height
-        )
-
-        return (backgroundRect, textRect)
-    }
-
+    /// Cliping 될 때 크기에 맞게 잘 잘리도록 전처리
     private func aspectFillRect(for size: CGSize, into slot: CGRect) -> CGRect {
         guard size.width > 0, size.height > 0 else { return slot }
 
@@ -140,5 +90,66 @@ struct PhotoFramePreview: View {
             let posY = slot.midY - height / 2 // 가운데 정렬(상하 잘림이 대칭)
             return CGRect(x: slot.minX, y: posY, width: width, height: height)
         }
+    }
+
+    /// 날짜 텍스트 뷰 생성 및 크기 계산
+    private func calculateDateViewSize(
+        parentSize: CGSize,
+        with context: GraphicsContext
+    ) -> (GraphicsContext.ResolvedText, CGSize) {
+        // 1. 현재 날짜 계산 및 형식 정리
+        let today = Date().formatted(
+            .dateTime.year(.defaultDigits)
+            .month(.twoDigits)
+            .day(.twoDigits)
+        ).replacingOccurrences(of: "-", with: ".")
+
+        // 2. 텍스트 크기 계산 및 스타일 설정
+        let fontSize = max(parentSize.width, parentSize.height) * 0.03
+        let dateText = Text(today)
+            .foregroundStyle(information.frame.textColor)
+            .font(.system(size: fontSize).bold())
+
+        // 3. 텍스트 뷰 크기 계산
+        let resolvedText = context.resolve(dateText)
+        let textSize = resolvedText.measure(in: CGSize(
+            width: CGFloat.greatestFiniteMagnitude,
+            height: CGFloat.greatestFiniteMagnitude
+        ))
+
+        return (resolvedText, textSize)
+    }
+
+    /// 날짜 배경 슬롯과 날짜 텍스트 슬롯 생성
+    private func dateRects(
+        parentSize: CGSize,
+        resolvedText: GraphicsContext.ResolvedText,
+        textSize: CGSize
+    ) -> (CGRect, CGRect) {
+        // 1. 날짜 입력 시작할 포인트 계산
+        let normalizedOrigin = information.layout.dateOrigin()
+        let dateOrigin = CGPoint(
+            x: normalizedOrigin.x * parentSize.width,
+            y: normalizedOrigin.y * parentSize.height
+        )
+
+        // 2. 배경 슬롯
+        let padding: CGFloat = 4
+        let backgroundRect = CGRect(
+            x: dateOrigin.x,
+            y: dateOrigin.y,
+            width: textSize.width + padding * 2,
+            height: textSize.height + padding
+        )
+
+        // 3. 텍스트 슬롯
+        let textRect = CGRect(
+            x: dateOrigin.x + padding,
+            y: dateOrigin.y + padding / 2,
+            width: textSize.width,
+            height: textSize.height
+        )
+
+        return (backgroundRect, textRect)
     }
 }

--- a/mirroringBooth/mirroringBooth/Device/Mirroring/PhotoComposition/Component/PhotoFramePreview.swift
+++ b/mirroringBooth/mirroringBooth/Device/Mirroring/PhotoComposition/Component/PhotoFramePreview.swift
@@ -13,64 +13,114 @@ struct PhotoFramePreview: View {
     var body: some View {
         GeometryReader { geometry in
             let size = geometry.size
-
-            Canvas { context, _ in
-                let canvas = CGRect(origin: .zero, size: size)
-
+            ZStack(alignment: .topLeading) {
                 // 1. 프레임 (배경)
                 if let frameImage = information.frame.image {
-                    let frameTarget = aspectFillRect(for: frameImage.size, into: canvas)
-                    context.draw(Image(uiImage: frameImage), in: frameTarget)
+                    Image(uiImage: frameImage)
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
                 }
 
                 // 2. 사진 슬롯들
                 let slots = information.layout.frameRects().map { $0.denormalized(in: size) }
-                for (index, slot) in slots.enumerated() {
-                    context.drawLayer { layer in
-                        layer.clip(to: Path(roundedRect: slot, cornerRadius: 5))
-
-                        if index < information.photos.count,
-                           let photoData = information.photos[index].imageData,
-                           let photo = UIImage(data: photoData) {
-                            let target = aspectFillRect(for: photo.size, into: slot)
-                            layer.draw(Image(uiImage: photo), in: target)
-                        } else {
-                            layer.fill(
-                                Path(roundedRect: slot, cornerRadius: 5),
-                                with: .color(information.frame == .white
-                                             ? .gray
-                                             : .white)
+                ForEach(Array(zip(slots.indices, slots)), id: \.0) { index, slot in
+                    Group {
+                        if index < information.photos.count {
+                            LocalAsyncImage(
+                                url: information.photos[index].url,
+                                slotAspect: slot.width / slot.height
                             )
+                        } else {
+                            RoundedRectangle(cornerRadius: 5)
+                                .fill(information.frame == .white ? .gray : .white)
                         }
                     }
+                    .frame(width: slot.width, height: slot.height)
+                    .offset( x: slot.minX, y: slot.minY)
                 }
 
                 // 3. 날짜
-                let (resolvedText, textSize) = calculateDateViewSize(parentSize: size, with: context)
-                let (backgroundRect, textRect) = dateRects(
-                    parentSize: size,
-                    resolvedText: resolvedText,
-                    textSize: textSize
-                )
+                let (backgroundRect, textRect) = dateRects(parentSize: size)
 
-                if let backgroundName = information.frame.dateBackgroundName {
-                    if let image = UIImage(named: backgroundName) {
-                        let target = aspectFillRect(for: image.size, into: backgroundRect)
-                            .insetBy(
-                                dx: -(textSize.width * 0.35),
-                                dy: -(textSize.height * 0.2)
-                            )
-                        context.draw(Image(uiImage: image), in: target)
-                    }
+                if let backgroundName = information.frame.dateBackgroundName,
+                   let image = UIImage(named: backgroundName) {
+                    let target = aspectFillRect(for: image.size, into: backgroundRect)
+                        .insetBy(
+                            dx: -(textRect.width * 0.35),
+                            dy: -(textRect.height * 0.2)
+                        )
+
+                    Image(uiImage: image)
+                        .resizable()
+                        .frame(width: target.width, height: target.height)
+                        .offset(x: target.minX, y: target.minY)
                 }
 
-                context.draw(resolvedText, in: textRect)
+                Text(formattedToday())
+                    .foregroundStyle(information.frame.textColor)
+                    .font(.system(size: dateFontSize(parentSize: size)).bold())
+                    .frame(width: textRect.width, height: textRect.height, alignment: .topLeading)
+                    .offset(x: textRect.minX, y: textRect.minY)
             }
         }
         .aspectRatio(information.layout.previewAspect, contentMode: .fit)
+        .clipped()
     }
 
-    /// Cliping 될 때 크기에 맞게 잘 잘리도록 전처리
+    private func formattedToday() -> String {
+        Date().formatted(
+            .dateTime.year(.defaultDigits)
+            .month(.twoDigits)
+            .day(.twoDigits)
+        )
+        .replacingOccurrences(of: "-", with: ".")
+    }
+
+    private func dateFontSize(parentSize: CGSize) -> CGFloat {
+        max(parentSize.width, parentSize.height) * 0.03
+    }
+
+    private func measureDateTextSize(parentSize: CGSize) -> CGSize {
+        let text = formattedToday()
+        let font = UIFont.systemFont(
+            ofSize: dateFontSize(parentSize: parentSize),
+            weight: .bold
+        )
+
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: font
+        ]
+
+        return (text as NSString).size(withAttributes: attributes)
+    }
+
+    private func dateRects(parentSize: CGSize) -> (CGRect, CGRect) {
+        let normalizedOrigin = information.layout.dateOrigin()
+        let dateOrigin = CGPoint(
+            x: normalizedOrigin.x * parentSize.width,
+            y: normalizedOrigin.y * parentSize.height
+        )
+
+        let textSize = measureDateTextSize(parentSize: parentSize)
+
+        let padding: CGFloat = 4
+        let backgroundRect = CGRect(
+            x: dateOrigin.x,
+            y: dateOrigin.y,
+            width: textSize.width + padding * 2,
+            height: textSize.height + padding
+        )
+
+        let textRect = CGRect(
+            x: dateOrigin.x + padding,
+            y: dateOrigin.y + padding / 2,
+            width: textSize.width,
+            height: textSize.height
+        )
+
+        return (backgroundRect, textRect)
+    }
+
     private func aspectFillRect(for size: CGSize, into slot: CGRect) -> CGRect {
         guard size.width > 0, size.height > 0 else { return slot }
 
@@ -90,66 +140,5 @@ struct PhotoFramePreview: View {
             let posY = slot.midY - height / 2 // 가운데 정렬(상하 잘림이 대칭)
             return CGRect(x: slot.minX, y: posY, width: width, height: height)
         }
-    }
-
-    /// 날짜 텍스트 뷰 생성 및 크기 계산
-    private func calculateDateViewSize(
-        parentSize: CGSize,
-        with context: GraphicsContext
-    ) -> (GraphicsContext.ResolvedText, CGSize) {
-        // 1. 현재 날짜 계산 및 형식 정리
-        let today = Date().formatted(
-            .dateTime.year(.defaultDigits)
-            .month(.twoDigits)
-            .day(.twoDigits)
-        ).replacingOccurrences(of: "-", with: ".")
-
-        // 2. 텍스트 크기 계산 및 스타일 설정
-        let fontSize = max(parentSize.width, parentSize.height) * 0.03
-        let dateText = Text(today)
-            .foregroundStyle(information.frame.textColor)
-            .font(.system(size: fontSize).bold())
-
-        // 3. 텍스트 뷰 크기 계산
-        let resolvedText = context.resolve(dateText)
-        let textSize = resolvedText.measure(in: CGSize(
-            width: CGFloat.greatestFiniteMagnitude,
-            height: CGFloat.greatestFiniteMagnitude
-        ))
-
-        return (resolvedText, textSize)
-    }
-
-    /// 날짜 배경 슬롯과 날짜 텍스트 슬롯 생성
-    private func dateRects(
-        parentSize: CGSize,
-        resolvedText: GraphicsContext.ResolvedText,
-        textSize: CGSize
-    ) -> (CGRect, CGRect) {
-        // 1. 날짜 입력 시작할 포인트 계산
-        let normalizedOrigin = information.layout.dateOrigin()
-        let dateOrigin = CGPoint(
-            x: normalizedOrigin.x * parentSize.width,
-            y: normalizedOrigin.y * parentSize.height
-        )
-
-        // 2. 배경 슬롯
-        let padding: CGFloat = 4
-        let backgroundRect = CGRect(
-            x: dateOrigin.x,
-            y: dateOrigin.y,
-            width: textSize.width + padding * 2,
-            height: textSize.height + padding
-        )
-
-        // 3. 텍스트 슬롯
-        let textRect = CGRect(
-            x: dateOrigin.x + padding,
-            y: dateOrigin.y + padding / 2,
-            width: textSize.width,
-            height: textSize.height
-        )
-
-        return (backgroundRect, textRect)
     }
 }

--- a/mirroringBooth/mirroringBooth/Device/Mirroring/PhotoComposition/Model/Photo.swift
+++ b/mirroringBooth/mirroringBooth/Device/Mirroring/PhotoComposition/Model/Photo.swift
@@ -13,10 +13,6 @@ struct Photo: Identifiable, Hashable {
     let url: URL
     let selectNumber: Int?
 
-    var imageData: Data? {
-        return try? Data(contentsOf: url)
-    }
-
     static func == (lhs: Photo, rhs: Photo) -> Bool {
         lhs.id == rhs.id
     }


### PR DESCRIPTION
## 🔗 연관된 이슈
- closed #259

## 📝 작업 내용

### 📌 요약 && 🔍 상세
- Photo 타입에서 imageData 제거
- LocalAsyncImage 사용

## 💬 리뷰 노트
- 사실상 기존의 Canvas 로직을 그대로 사용했습니다
- 달라진 것이 있다면 `.clipped()` 적용 위치..?
- 원래는 없었던 것 같은데 현재 사진 선택 시 애니메이션이 적용되고 있습니다. 제거할까요?
  - 원래 있었다면 노터치로... 😂
- 날짜 배경이 조금 아래로 치우쳐진것 같긴 한데 오차범위 내인 것 같아서 일단은 냅뒀습니다

## 📸 영상 / 이미지 (Optional)

<table>
<tr>
<td><video src="https://github.com/user-attachments/assets/29f5e624-a64d-4f19-aa9f-6c2b8a6b5be8">
<td><img alt="image" src="https://github.com/user-attachments/assets/c0816b4f-ec66-4fc4-b8c4-ba545c24a6d0"/>
</tr>
<tr>
<td align="center">애니메이션이 적용되는 중
<td align="center">2x2
</tr>
<tr>

<td><img alt="image" src="https://github.com/user-attachments/assets/a58cf4c2-5252-4aa8-a06b-01e4e9ad7ad8" />
<td>
<img alt="image" src="https://github.com/user-attachments/assets/03169981-126a-48b8-a2ff-c0419fa2784a" />
</tr>
<tr>
<td align="center">1x1
<td align="center">2x1
</tr>
<tr>
<td><img alt="image" src="https://github.com/user-attachments/assets/f52e3069-ea8a-48c7-b7ec-a1bde1fded34" />
<td>
<img alt="image" src="https://github.com/user-attachments/assets/05b3e699-40c4-46d2-a9f2-221cea4cedcf" />

</tr>
<tr>
<td align="center">4x1
<td align="center">2x3
</tr>

<tr>
<td align="center"><img alt="image" src="https://github.com/user-attachments/assets/d07589ff-faf4-47be-ba6f-6af23b229a37" />
</tr>

<tr>
<td align="center">
</tr>

</table>