### PR TITLE
[Refactor/#283] Advertiser 책임을 분리한다.

### DIFF
--- a/mirroringBooth/mirroringBooth.xcodeproj/project.pbxproj
+++ b/mirroringBooth/mirroringBooth.xcodeproj/project.pbxproj
@@ -19,7 +19,7 @@
 			remoteGlobalIDString = 8C796EA92EF52FB200280FED;
 			remoteInfo = mirroringBooth;
 		};
-		8CC15B3B2F30748C00F1137E /* PBXContainerItemProxy */ = {
+		0C4E9AA82F331EE300384D23 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 8C796EA22EF52FB200280FED /* Project object */;
 			proxyType = 1;
@@ -442,15 +442,15 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		8CC15B3C2F30748C00F1137E /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 8C796EA92EF52FB200280FED /* mirroringBooth */;
-    };
-			targetProxy = 8CC15B3B2F30748C00F1137E /* PBXContainerItemProxy */;
 		0C2009892F306ED700B6197B /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 8C796EA92EF52FB200280FED /* mirroringBooth */;
 			targetProxy = 0C2009882F306ED700B6197B /* PBXContainerItemProxy */;
+		};
+		8CC15B3C2F30748C00F1137E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 8C796EA92EF52FB200280FED /* mirroringBooth */;
+			targetProxy = 0C4E9AA82F331EE300384D23 /* PBXContainerItemProxy */;
 		};
 		8CC15D892F30E17B00F1137E /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/mirroringBooth/mirroringBooth/Core/AppLogger.swift
+++ b/mirroringBooth/mirroringBooth/Core/AppLogger.swift
@@ -13,6 +13,7 @@ extension Logger {
     static let modeSelectionView = Logger(subsystem: subsystem, category: "ModeSelectionView")
 
     static let advertiser = Logger(subsystem: subsystem, category: "Advertiser")
+    static let advertisingManager = Logger(subsystem: subsystem, category: "AdvertisingManager")
     static let browser = Logger(subsystem: subsystem, category: "Browser")
 
     static let h264encoder = Logger(subsystem: subsystem, category: "H264Encoder")

--- a/mirroringBooth/mirroringBooth/Core/AppLogger.swift
+++ b/mirroringBooth/mirroringBooth/Core/AppLogger.swift
@@ -14,6 +14,7 @@ extension Logger {
 
     static let advertiser = Logger(subsystem: subsystem, category: "Advertiser")
     static let advertisingManager = Logger(subsystem: subsystem, category: "AdvertisingManager")
+    static let advertiserCommandmanager = Logger(subsystem: subsystem, category: "AdvertiserCommandmanager")
     static let browser = Logger(subsystem: subsystem, category: "Browser")
 
     static let h264encoder = Logger(subsystem: subsystem, category: "H264Encoder")

--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/Browser.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/Browser.swift
@@ -16,7 +16,7 @@ final class Browser: NSObject {
         case navigateToSelectModeWithRemote
         case navigateToSelectModeWithoutRemote
         case switchSelectModeView
-        case allPhotosStored // 사진 10장 모두 저장 완료
+        case onStoreAllPhotos // 사진 10장 저장 시작 명령(from camera)
         case onUpdateCaptureCount   //  리모트 기기에서 카메라 캡처 요청 보내기
         case heartBeat
         case captureEffect

--- a/mirroringBooth/mirroringBooth/Device/Camera/Streaming/CameraPreviewStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Streaming/CameraPreviewStore.swift
@@ -142,7 +142,7 @@ private extension CameraPreviewStore {
             framedData.append(data)
 
             self.browser.sendStreamData(framedData)
-        }   
+        }
 
         // 전송 완료
         cameraManager.onTransferCompleted = { [weak self] in
@@ -154,7 +154,7 @@ private extension CameraPreviewStore {
         // 10장 모두 저장 완료 시 미러링기기에 알림 전송
         cameraManager.onAllPhotosStored = { [weak self] _ in
             Task { @MainActor in
-                self?.browser.sendCommand(.allPhotosStored)
+                self?.browser.sendCommand(.onStoreAllPhotos)
                 self?.reduce(.captureCompleted)
                 self?.reduce(.setTransferCount(0))
             }

--- a/mirroringBooth/mirroringBooth/Device/Common/HeartBeater/Advertiser+HeartBeater.swift
+++ b/mirroringBooth/mirroringBooth/Device/Common/HeartBeater/Advertiser+HeartBeater.swift
@@ -18,6 +18,6 @@ extension Advertiser: HeartBeaterDelegate {
     }
 
     func onTimeout(_ sender: HeartBeater) {
-        streamManager.yieldRootEvent(.onHeartbeatTimeout)
+        streamManager.yieldRoot(.onHeartbeatTimeout)
     }
 }

--- a/mirroringBooth/mirroringBooth/Device/Common/HeartBeater/Advertiser+HeartBeater.swift
+++ b/mirroringBooth/mirroringBooth/Device/Common/HeartBeater/Advertiser+HeartBeater.swift
@@ -18,6 +18,6 @@ extension Advertiser: HeartBeaterDelegate {
     }
 
     func onTimeout(_ sender: HeartBeater) {
-        rootContinuation.yield(.onHeartbeatTimeout)
+        streamManager.yieldRootEvent(.onHeartbeatTimeout)
     }
 }

--- a/mirroringBooth/mirroringBooth/Device/Remote/RemoteCaptureView.swift
+++ b/mirroringBooth/mirroringBooth/Device/Remote/RemoteCaptureView.swift
@@ -28,5 +28,8 @@ struct RemoteCaptureView: View {
                 }
             }
         }
+        .task {
+            
+        }
     }
 }

--- a/mirroringBooth/mirroringBooth/Device/Remote/RemoteCaptureView.swift
+++ b/mirroringBooth/mirroringBooth/Device/Remote/RemoteCaptureView.swift
@@ -28,8 +28,5 @@ struct RemoteCaptureView: View {
                 }
             }
         }
-        .task {
-            
-        }
     }
 }

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Advertiser.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Advertiser.swift
@@ -18,33 +18,22 @@ final class Advertiser: NSObject {
     private let peerID: MCPeerID
     private var session: MCSession?
     private var commandSession: MCSession?
-    private let advertiser: MCNearbyServiceAdvertiser
     private let photoCacheManager: PhotoCacheManager
     private let heartBeater: HeartBeater
-    private var isBlockingInvitation: Bool = false
     var advertiserType: DeviceUseType = .mirroring // heartbeat 메시지 종류 구분을 위해 추가
     let myDeviceName: String
 
-    private let videoContinuation: AsyncStream<FrameReceivingEvents>.Continuation
-    let videoStream: AsyncStream<FrameReceivingEvents>
+    let connectionManager: AdvertisingManager
+    let streamManager = StreamManager()
+    private let commandManager: AdvertiserCommandManager
 
-    private let advertisingContinuation: AsyncStream<AdvertiserEvents>.Continuation
-    let advertisingStream: AsyncStream<AdvertiserEvents>
-
-    private let modeSelectionContinuation: AsyncStream<ModeSelectionEvents>.Continuation
-    let modeSelectionStream: AsyncStream<ModeSelectionEvents>
-
-    private let remoteConnectedViewContinuation: AsyncStream<RemoteConnectedViewEvents>.Continuation
-    let remoteConnectedViewStream: AsyncStream<RemoteConnectedViewEvents>
-
-    private let remoteCaptureViewContinuation: AsyncStream<RemoteCaptureViewEvents>.Continuation
-    let remoteCaptureViewStream: AsyncStream<RemoteCaptureViewEvents>
-
-    private let streamingStoreContinuation: AsyncStream<StreamingStoreEvents>.Continuation
-    let streamingStoreStream: AsyncStream<StreamingStoreEvents>
-
-    let rootContinuation: AsyncStream<RootEvents>.Continuation
-    let rootStream: AsyncStream<RootEvents>
+    var videoStream: AsyncStream<FrameReceivingEvents> { streamManager.videoStream }
+    var advertisingStream: AsyncStream<AdvertiserEvents> { streamManager.advertisingStream }
+    var modeSelectionStream: AsyncStream<ModeSelectionEvents> { streamManager.modeSelectionStream }
+    var remoteConnectedViewStream: AsyncStream<RemoteConnectedViewEvents> { streamManager.remoteConnectedViewStream }
+    var remoteCaptureViewStream: AsyncStream<RemoteCaptureViewEvents> { streamManager.remoteCaptureViewStream }
+    var streamingStoreStream: AsyncStream<StreamingStoreEvents> { streamManager.streamingStoreStream }
+    var rootStream: AsyncStream<RootEvents> { streamManager.rootStream }
 
     /// 카메라 기기에게 보내는 명령
     enum CameraDeviceCommand: String {
@@ -80,31 +69,21 @@ final class Advertiser: NSObject {
         #endif
         }()
 
-        self.advertiser = MCNearbyServiceAdvertiser(
-            peer: peerID,
-            discoveryInfo: ["deviceType": myDeviceType],
-            serviceType: serviceType
+        self.connectionManager = AdvertisingManager(
+            serviceType: serviceType,
+            peerID: peerID,
+            discoveryInfo: ["deviceType": myDeviceType]
         )
         self.photoCacheManager = photoCacheManager
         self.heartBeater = HeartBeater(repeatInterval: 1.0, timeout: 2.5)
-        (videoStream, videoContinuation) = AsyncStream.makeStream(
-            of: FrameReceivingEvents.self,
-            bufferingPolicy: .bufferingNewest(1)
-        )
-        (advertisingStream, advertisingContinuation) = AsyncStream.makeStream(of: AdvertiserEvents.self)
-        (modeSelectionStream, modeSelectionContinuation) = AsyncStream.makeStream(of: ModeSelectionEvents.self)
-        (remoteConnectedViewStream, remoteConnectedViewContinuation) = AsyncStream.makeStream(
-            of: RemoteConnectedViewEvents.self
-        )
-        (remoteCaptureViewStream, remoteCaptureViewContinuation) = AsyncStream.makeStream(
-            of: RemoteCaptureViewEvents.self
-        )
-        (streamingStoreStream, streamingStoreContinuation) = AsyncStream.makeStream(of: StreamingStoreEvents.self)
 
-        (rootStream, rootContinuation) = AsyncStream.makeStream(of: RootEvents.self)
-
+        self.commandManager = AdvertiserCommandManager(streamManager: streamManager, heartBeater: heartBeater)
         super.init()
-        advertiser.delegate = self
+
+        connectionManager.delegate = self
+        connectionManager.connectedPeersCheck = { [weak self] peerID in
+            self?.commandSession?.connectedPeers.contains(peerID) == true
+        }
         heartBeater.delegate = self
     }
 
@@ -115,18 +94,11 @@ final class Advertiser: NSObject {
     }
 
     func startSearching() {
-        isBlockingInvitation = false
-        advertiser.startAdvertisingPeer()
-        logger.info("광고를 시작합니다.")
+        connectionManager.startSearching()
     }
 
     func stopSearching(onlyRefuse: Bool = false) {
-        if onlyRefuse {
-            isBlockingInvitation = true
-            return
-        }
-        advertiser.stopAdvertisingPeer()
-        logger.info("광고를 중단합니다.")
+        connectionManager.stopSearching(onlyRefuse: onlyRefuse)
     }
 
     /// 세션과 연결을 해제합니다.
@@ -146,72 +118,7 @@ final class Advertiser: NSObject {
 
     /// 연결된 카메라 기기(iPhone)에게 명령을 전송합니다.
     func sendCommand(_ command: CameraDeviceCommand) {
-        guard let commandSession, let commandData = command.rawValue.data(using: .utf8) else { return }
-        let connectedPeers = commandSession.connectedPeers
-        guard !connectedPeers.isEmpty else {
-            logger.warning("명령 전송 실패: commandSession에 연결된 피어가 없습니다")
-            return
-        }
-
-        do {
-            try commandSession.send(commandData, toPeers: connectedPeers, with: .reliable)
-            if command != .heartBeat {
-                logger.info("촬영 명령 전송: \(command.rawValue)")
-            }
-        } catch {
-            logger.warning("명령 전송 실패: \(error.localizedDescription)")
-        }
-    }
-
-    private func executeCommand(data: Data) {
-        guard let command = String(data: data, encoding: .utf8) else { return }
-
-        if let mirroringDeviceCommand = Browser.MirroringDeviceCommand(rawValue: command) {
-            handleMirroringDeviceCommand(mirroringDeviceCommand)
-            return
-        }
-
-        if let remoteDeviceCommand = Browser.RemoteDeviceCommand(rawValue: command) {
-            handleRemoteDeviceCommand(remoteDeviceCommand)
-            return
-        }
-    }
-
-    private func handleMirroringDeviceCommand(_ mirroringDeviceCommand: Browser.MirroringDeviceCommand) {
-        switch mirroringDeviceCommand {
-        case .navigateToSelectModeWithRemote:
-            advertisingContinuation.yield(.navigateToSelectModeCommand(true))
-        case .navigateToSelectModeWithoutRemote:
-            advertisingContinuation.yield(.navigateToSelectModeCommand(false))
-        case .switchSelectModeView:
-            modeSelectionContinuation.yield(.switchModeSelectionView)
-        case .allPhotosStored:
-            streamingStoreContinuation.yield(.onStoreAllPhotos)
-        case .onUpdateCaptureCount:
-            streamingStoreContinuation.yield(.onUpdateCaptureCount)
-        case .heartBeat:
-            heartBeater.beat()
-        case .captureEffect:
-            streamingStoreContinuation.yield(.onCaptureEffect)
-        }
-    }
-
-    private func handleRemoteDeviceCommand(_ remoteDeviceCommand: Browser.RemoteDeviceCommand) {
-        switch remoteDeviceCommand {
-        case .navigateToRemoteConnected:
-            advertisingContinuation.yield(.navigateToRemoteConnected)
-        case .navigateToRemoteCapture:
-            remoteConnectedViewContinuation.yield(.navigateToRemoteCapture)
-        case .navigateToRemoteComplete:
-            remoteCaptureViewContinuation.yield(.navigateToRemoteComplete)
-        case .navigateToHome:
-            remoteConnectedViewContinuation.yield(.navigateToHome)
-        case .noticeIsRemoteDevice:
-            advertiserType = .remote
-            heartBeater.start()
-        case .heartBeat:
-            heartBeater.beat()
-        }
+        commandManager.send(command, session: commandSession)
     }
 }
 
@@ -224,7 +131,7 @@ extension Advertiser: MCSessionDelegate {
         }
         if session === self.commandSession {
             if state == .connected {
-                advertisingContinuation.yield(.onConnected)
+                streamManager.yieldAdvertisingEvent(.onConnected)
             }
         }
     }
@@ -232,10 +139,10 @@ extension Advertiser: MCSessionDelegate {
     func session(_ session: MCSession, didReceive data: Data, fromPeer peerID: MCPeerID) {
         if session === self.session {
             // 스트림 세션에서 수신
-            videoContinuation.yield(.streamDataReceived(data))
+            streamManager.yieldVideoData(data)
         } else if session === commandSession {
             // 명령 세션에서 수신
-            executeCommand(data: data)
+            commandManager.execute(data: data, advertiserType: &advertiserType)
         }
     }
 
@@ -282,49 +189,19 @@ extension Advertiser: MCSessionDelegate {
             }
         }
         /// 사진 수신 완료
-        streamingStoreContinuation.yield(.onPhotoReceived)
+        streamManager.yieldStreamingStoreEvent(.onPhotoReceived)
     }
 }
 
-// MARK: - Advertiser Delegate
-// 주변 기기로부터 들어오는 연결 초대를 수신한 뒤 승인 및 거절을 처리합니다.
-extension Advertiser: MCNearbyServiceAdvertiserDelegate {
-    func advertiser(_ advertiser: MCNearbyServiceAdvertiser,
-                    didReceiveInvitationFromPeer peerID: MCPeerID,
-                    withContext context: Data?,
-                    invitationHandler: @escaping (Bool, MCSession?) -> Void) {
-        guard let context,
-              let type = String(data: context, encoding: .utf8) else {
-            logger.warning("초대 수신 실패: context 파싱 불가 - \(peerID.displayName)")
-            invitationHandler(false, nil)
-            return
-        }
-        guard isBlockingInvitation == false
-                || (commandSession?.connectedPeers.contains(peerID) == true) else {
-            invitationHandler(false, nil)
-            return
-        }
-
-        logger.info("초대 수신: \(peerID.displayName)(타입: \(type))")
+// MARK: - ConnectionManager Delegate
+extension Advertiser: ConnectionManagerDelegate {
+    func connectionManager(_ manager: AdvertisingManager, didCreateSession session: MCSession, type: String) {
         if type == "streaming" {
-            // invite를 수락하는 시점에 session을 생성
-            self.session = MCSession(
-                peer: self.peerID,
-                securityIdentity: nil,
-                encryptionPreference: .required
-            )
-            session?.delegate = self
-            invitationHandler(true, session)
+            self.session = session
+            session.delegate = self
         } else if type == "command" {
-            self.commandSession = MCSession(
-                peer: self.peerID,
-                securityIdentity: nil,
-                encryptionPreference: .none
-            )
-            commandSession?.delegate = self
-            invitationHandler(true, commandSession)
-        } else {
-            invitationHandler(false, nil)
+            self.commandSession = session
+            session.delegate = self
         }
     }
 }

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Advertiser.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Advertiser.swift
@@ -100,6 +100,7 @@ final class Advertiser: NSObject {
             of: RemoteCaptureViewEvents.self
         )
         (streamingStoreStream, streamingStoreContinuation) = AsyncStream.makeStream(of: StreamingStoreEvents.self)
+
         (rootStream, rootContinuation) = AsyncStream.makeStream(of: RootEvents.self)
 
         super.init()

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Advertiser.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Advertiser.swift
@@ -94,11 +94,11 @@ final class Advertiser: NSObject {
     }
 
     func startSearching() {
-        connectionManager.startSearching()
+        connectionManager.startAdvertising()
     }
 
     func stopSearching(onlyRefuse: Bool = false) {
-        connectionManager.stopSearching(onlyRefuse: onlyRefuse)
+        connectionManager.stopAdvertising(onlyRefuse: onlyRefuse)
     }
 
     /// 세션과 연결을 해제합니다.
@@ -129,17 +129,15 @@ extension Advertiser: MCSessionDelegate {
         if session === self.session, state == .connected {
             heartBeater.start()
         }
-        if session === self.commandSession {
-            if state == .connected {
-                streamManager.yieldAdvertisingEvent(.onConnected)
-            }
+        if session === self.commandSession, state == .connected {
+                streamManager.yieldAdvertising(.onConnected)
         }
     }
 
     func session(_ session: MCSession, didReceive data: Data, fromPeer peerID: MCPeerID) {
         if session === self.session {
             // 스트림 세션에서 수신
-            streamManager.yieldVideoData(data)
+            streamManager.yieldVideo(data)
         } else if session === commandSession {
             // 명령 세션에서 수신
             commandManager.execute(data: data, advertiserType: &advertiserType)
@@ -189,7 +187,7 @@ extension Advertiser: MCSessionDelegate {
             }
         }
         /// 사진 수신 완료
-        streamManager.yieldStreamingStoreEvent(.onPhotoReceived)
+        streamManager.yieldStreamingStore(.onPhotoReceived)
     }
 }
 

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertisingStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertisingStore.swift
@@ -50,7 +50,6 @@ final class AdvertisingStore: StoreProtocol {
         case .exit:
             commandTask?.cancel()
             advertiser.stopSearching()
-            return []
 
         case .connected:
             advertiser.stopSearching(onlyRefuse: true)
@@ -59,6 +58,8 @@ final class AdvertisingStore: StoreProtocol {
         case .setShowTutorial(let value):
             return [.setShowTutorial(value)]
         }
+
+        return []
     }
 
     func reduce(_ result: Result) {

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Manager/AdvertiserCommandManager.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Manager/AdvertiserCommandManager.swift
@@ -42,8 +42,8 @@ final class AdvertiserCommandManager {
             streamManager?.yieldAdvertising(.navigateToSelectModeCommand(false))
         case .switchSelectModeView:
             streamManager?.yieldModeSelection(.switchModeSelectionView)
-        case .allPhotosStored:
-            streamManager?.yieldStreamingStore(.onAllPhotosStored)
+        case .onStoreAllPhotos:
+            streamManager?.yieldStreamingStore(.onStoreAllPhotos)
         case .onUpdateCaptureCount:
             streamManager?.yieldStreamingStore(.onUpdateCaptureCount)
         case .heartBeat:

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Manager/AdvertiserCommandManager.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Manager/AdvertiserCommandManager.swift
@@ -1,0 +1,92 @@
+//
+//  CommandManager.swift
+//  mirroringBooth
+//
+//  Created by Liam on 2/3/26.
+//
+
+import Foundation
+import MultipeerConnectivity
+import OSLog
+
+/// 명령 송수신 및 처리를 담당하는 매니저
+final class AdvertiserCommandManager {
+    private weak var streamManager: StreamManager?
+    private weak var heartBeater: HeartBeater?
+
+    init(streamManager: StreamManager, heartBeater: HeartBeater) {
+        self.streamManager = streamManager
+        self.heartBeater = heartBeater
+    }
+
+    // MARK: - Command Execution
+    func execute(data: Data, advertiserType: inout DeviceUseType) {
+        guard let commandString = String(data: data, encoding: .utf8) else { return }
+
+        if let mirroringDeviceCommand = Browser.MirroringDeviceCommand(rawValue: commandString) {
+            handleMirroringDeviceCommand(mirroringDeviceCommand)
+            return
+        }
+
+        if let remoteDeviceCommand = Browser.RemoteDeviceCommand(rawValue: commandString) {
+            handleRemoteDeviceCommand(remoteDeviceCommand, advertiserType: &advertiserType)
+            return
+        }
+    }
+
+    private func handleMirroringDeviceCommand(_ command: Browser.MirroringDeviceCommand) {
+        switch command {
+        case .navigateToSelectModeWithRemote:
+            streamManager?.yieldAdvertisingEvent(.navigateToSelectModeCommand(true))
+        case .navigateToSelectModeWithoutRemote:
+            streamManager?.yieldAdvertisingEvent(.navigateToSelectModeCommand(false))
+        case .switchSelectModeView:
+            streamManager?.yieldModeSelectionEvent(.switchModeSelectionView)
+        case .allPhotosStored:
+            streamManager?.yieldStreamingStoreEvent(.onAllPhotosStored)
+        case .onUpdateCaptureCount:
+            streamManager?.yieldStreamingStoreEvent(.onUpdateCaptureCount)
+        case .heartBeat:
+            heartBeater?.beat()
+        case .captureEffect:
+            streamManager?.yieldStreamingStoreEvent(.onCaptureEffect)
+        }
+    }
+
+    private func handleRemoteDeviceCommand(_ command: Browser.RemoteDeviceCommand, advertiserType: inout DeviceUseType) {
+        switch command {
+        case .navigateToRemoteConnected:
+            streamManager?.yieldAdvertisingEvent(.navigateToRemoteConnected)
+        case .navigateToRemoteCapture:
+            streamManager?.yieldRemoteConnectedViewEvent(.navigateToRemoteCapture)
+        case .navigateToRemoteComplete:
+            streamManager?.yieldRemoteCaptureViewEvent(.navigateToRemoteComplete)
+        case .navigateToHome:
+            streamManager?.yieldRemoteConnectedViewEvent(.navigateToHome)
+        case .noticeIsRemoteDevice:
+            advertiserType = .remote
+            heartBeater?.start()
+        case .heartBeat:
+            heartBeater?.beat()
+        }
+    }
+
+    // MARK: - Command Sending
+    func send(_ command: Advertiser.CameraDeviceCommand, session: MCSession?) {
+        guard let session, let commandData = command.rawValue.data(using: .utf8) else { return }
+        let connectedPeers = session.connectedPeers
+        guard !connectedPeers.isEmpty else {
+            Logger.advertiserCommandmanager.warning("명령 전송 실패: commandSession에 연결된 피어가 없습니다")
+            return
+        }
+
+        do {
+            try session.send(commandData, toPeers: connectedPeers, with: .reliable)
+            if command != .heartBeat {
+                Logger.advertiserCommandmanager.info("촬영 명령 전송: \(command.rawValue)")
+            }
+        } catch {
+            Logger.advertiserCommandmanager.warning("명령 전송 실패: \(error.localizedDescription)")
+        }
+    }
+}

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Manager/AdvertiserCommandManager.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Manager/AdvertiserCommandManager.swift
@@ -53,7 +53,10 @@ final class AdvertiserCommandManager {
         }
     }
 
-    private func handleRemoteDeviceCommand(_ command: Browser.RemoteDeviceCommand, advertiserType: inout DeviceUseType) {
+    private func handleRemoteDeviceCommand(
+        _ command: Browser.RemoteDeviceCommand,
+        advertiserType: inout DeviceUseType
+    ) {
         switch command {
         case .navigateToRemoteConnected:
             streamManager?.yieldAdvertisingEvent(.navigateToRemoteConnected)

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Manager/AdvertiserCommandManager.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Manager/AdvertiserCommandManager.swift
@@ -37,19 +37,19 @@ final class AdvertiserCommandManager {
     private func handleMirroringDeviceCommand(_ command: Browser.MirroringDeviceCommand) {
         switch command {
         case .navigateToSelectModeWithRemote:
-            streamManager?.yieldAdvertisingEvent(.navigateToSelectModeCommand(true))
+            streamManager?.yieldAdvertising(.navigateToSelectModeCommand(true))
         case .navigateToSelectModeWithoutRemote:
-            streamManager?.yieldAdvertisingEvent(.navigateToSelectModeCommand(false))
+            streamManager?.yieldAdvertising(.navigateToSelectModeCommand(false))
         case .switchSelectModeView:
-            streamManager?.yieldModeSelectionEvent(.switchModeSelectionView)
+            streamManager?.yieldModeSelection(.switchModeSelectionView)
         case .allPhotosStored:
-            streamManager?.yieldStreamingStoreEvent(.onAllPhotosStored)
+            streamManager?.yieldStreamingStore(.onAllPhotosStored)
         case .onUpdateCaptureCount:
-            streamManager?.yieldStreamingStoreEvent(.onUpdateCaptureCount)
+            streamManager?.yieldStreamingStore(.onUpdateCaptureCount)
         case .heartBeat:
             heartBeater?.beat()
         case .captureEffect:
-            streamManager?.yieldStreamingStoreEvent(.onCaptureEffect)
+            streamManager?.yieldStreamingStore(.onCaptureEffect)
         }
     }
 
@@ -59,13 +59,13 @@ final class AdvertiserCommandManager {
     ) {
         switch command {
         case .navigateToRemoteConnected:
-            streamManager?.yieldAdvertisingEvent(.navigateToRemoteConnected)
+            streamManager?.yieldAdvertising(.navigateToRemoteConnected)
         case .navigateToRemoteCapture:
-            streamManager?.yieldRemoteConnectedViewEvent(.navigateToRemoteCapture)
+            streamManager?.yieldRemoteConnectedView(.navigateToRemoteCapture)
         case .navigateToRemoteComplete:
-            streamManager?.yieldRemoteCaptureViewEvent(.navigateToRemoteComplete)
+            streamManager?.yieldRemoteCaptureView(.navigateToRemoteComplete)
         case .navigateToHome:
-            streamManager?.yieldRemoteConnectedViewEvent(.navigateToHome)
+            streamManager?.yieldRemoteConnectedView(.navigateToHome)
         case .noticeIsRemoteDevice:
             advertiserType = .remote
             heartBeater?.start()

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Manager/AdvertisingManager.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Manager/AdvertisingManager.swift
@@ -30,13 +30,13 @@ final class AdvertisingManager: NSObject {
         self.advertiser.delegate = self
     }
 
-    func startSearching() {
+    func startAdvertising() {
         isBlockingInvitation = false
         advertiser.startAdvertisingPeer()
         Logger.advertisingManager.info("광고를 시작합니다.")
     }
 
-    func stopSearching(onlyRefuse: Bool = false) {
+    func stopAdvertising(onlyRefuse: Bool = false) {
         if onlyRefuse {
             isBlockingInvitation = true
             return

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Manager/AdvertisingManager.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Manager/AdvertisingManager.swift
@@ -60,14 +60,12 @@ extension AdvertisingManager: MCNearbyServiceAdvertiserDelegate {
 
         // 이미 연결된 피어인지 확인
         let isAlreadyConnected = connectedPeersCheck?(peerID) ?? false
-        
         guard isBlockingInvitation == false || isAlreadyConnected else {
             invitationHandler(false, nil)
             return
         }
-
         Logger.advertisingManager.info("초대 수신: \(peerID.displayName)(타입: \(type))")
-        
+
         // 세션 생성
         let session: MCSession
         if type == "streaming" {
@@ -86,10 +84,8 @@ extension AdvertisingManager: MCNearbyServiceAdvertiserDelegate {
             invitationHandler(false, nil)
             return
         }
-        
         // 델리게이트에게 알림 (Advertiser가 세션을 저장하고 Delegate를 설정하도록)
         delegate?.connectionManager(self, didCreateSession: session, type: type)
-        
         invitationHandler(true, session)
     }
 }

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Manager/AdvertisingManager.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Manager/AdvertisingManager.swift
@@ -1,0 +1,95 @@
+//
+//  AdvertisingManager.swift
+//  mirroringBooth
+//
+//  Created by Liam on 2/3/26.
+//
+
+import Foundation
+import MultipeerConnectivity
+import OSLog
+
+protocol ConnectionManagerDelegate: AnyObject {
+    func connectionManager(_ manager: AdvertisingManager, didCreateSession session: MCSession, type: String)
+}
+
+final class AdvertisingManager: NSObject {
+    private let advertiser: MCNearbyServiceAdvertiser
+    private var isBlockingInvitation: Bool = false
+
+    weak var delegate: ConnectionManagerDelegate?
+    var connectedPeersCheck: ((MCPeerID) -> Bool)? // 특정 피어가 이미 연결되어 있는지 확인하는 클로저
+
+    init(serviceType: String, peerID: MCPeerID, discoveryInfo: [String: String]?) {
+        self.advertiser = MCNearbyServiceAdvertiser(
+            peer: peerID,
+            discoveryInfo: discoveryInfo,
+            serviceType: serviceType
+        )
+        super.init()
+        self.advertiser.delegate = self
+    }
+
+    func startSearching() {
+        isBlockingInvitation = false
+        advertiser.startAdvertisingPeer()
+        Logger.advertisingManager.info("광고를 시작합니다.")
+    }
+
+    func stopSearching(onlyRefuse: Bool = false) {
+        if onlyRefuse {
+            isBlockingInvitation = true
+            return
+        }
+        advertiser.stopAdvertisingPeer()
+        Logger.advertisingManager.info("광고를 중단합니다.")
+    }
+}
+
+extension AdvertisingManager: MCNearbyServiceAdvertiserDelegate {
+    func advertiser(_ advertiser: MCNearbyServiceAdvertiser,
+                    didReceiveInvitationFromPeer peerID: MCPeerID,
+                    withContext context: Data?,
+                    invitationHandler: @escaping (Bool, MCSession?) -> Void) {
+        guard let context,
+              let type = String(data: context, encoding: .utf8) else {
+            Logger.advertisingManager.warning("초대 수신 실패: context 파싱 불가 - \(peerID.displayName)")
+            invitationHandler(false, nil)
+            return
+        }
+
+        // 이미 연결된 피어인지 확인
+        let isAlreadyConnected = connectedPeersCheck?(peerID) ?? false
+        
+        guard isBlockingInvitation == false || isAlreadyConnected else {
+            invitationHandler(false, nil)
+            return
+        }
+
+        Logger.advertisingManager.info("초대 수신: \(peerID.displayName)(타입: \(type))")
+        
+        // 세션 생성
+        let session: MCSession
+        if type == "streaming" {
+            session = MCSession(
+                peer: advertiser.myPeerID,
+                securityIdentity: nil,
+                encryptionPreference: .required
+            )
+        } else if type == "command" {
+            session = MCSession(
+                peer: advertiser.myPeerID,
+                securityIdentity: nil,
+                encryptionPreference: .none
+            )
+        } else {
+            invitationHandler(false, nil)
+            return
+        }
+        
+        // 델리게이트에게 알림 (Advertiser가 세션을 저장하고 Delegate를 설정하도록)
+        delegate?.connectionManager(self, didCreateSession: session, type: type)
+        
+        invitationHandler(true, session)
+    }
+}

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Manager/StreamManager.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Manager/StreamManager.swift
@@ -44,31 +44,31 @@ final class StreamManager {
     }
 
     // MARK: - Yield Methods
-    func yieldVideoData(_ data: Data) {
+    func yieldVideo(_ data: Data) {
         videoContinuation.yield(.streamDataReceived(data))
     }
 
-    func yieldAdvertisingEvent(_ event: AdvertiserEvents) {
+    func yieldAdvertising(_ event: AdvertiserEvents) {
         advertisingContinuation.yield(event)
     }
 
-    func yieldModeSelectionEvent(_ event: ModeSelectionEvents) {
+    func yieldModeSelection(_ event: ModeSelectionEvents) {
         modeSelectionContinuation.yield(event)
     }
 
-    func yieldRemoteConnectedViewEvent(_ event: RemoteConnectedViewEvents) {
+    func yieldRemoteConnectedView(_ event: RemoteConnectedViewEvents) {
         remoteConnectedViewContinuation.yield(event)
     }
 
-    func yieldRemoteCaptureViewEvent(_ event: RemoteCaptureViewEvents) {
+    func yieldRemoteCaptureView(_ event: RemoteCaptureViewEvents) {
         remoteCaptureViewContinuation.yield(event)
     }
 
-    func yieldStreamingStoreEvent(_ event: StreamingStoreEvents) {
+    func yieldStreamingStore(_ event: StreamingStoreEvents) {
         streamingStoreContinuation.yield(event)
     }
 
-    func yieldRootEvent(_ event: RootEvents) {
+    func yieldRoot(_ event: RootEvents) {
         rootContinuation.yield(event)
     }
 }

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Manager/StreamManager.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Manager/StreamManager.swift
@@ -1,0 +1,74 @@
+//
+//  StreamManager.swift
+//  mirroringBooth
+//
+//  Created by Liam on 2/3/26.
+//
+
+import Foundation
+
+final class StreamManager {
+    // MARK: - Continuations
+    private let videoContinuation: AsyncStream<FrameReceivingEvents>.Continuation
+    private let advertisingContinuation: AsyncStream<AdvertiserEvents>.Continuation
+    private let modeSelectionContinuation: AsyncStream<ModeSelectionEvents>.Continuation
+    private let remoteConnectedViewContinuation: AsyncStream<RemoteConnectedViewEvents>.Continuation
+    private let remoteCaptureViewContinuation: AsyncStream<RemoteCaptureViewEvents>.Continuation
+    private let streamingStoreContinuation: AsyncStream<StreamingStoreEvents>.Continuation
+    private let rootContinuation: AsyncStream<RootEvents>.Continuation
+
+    // MARK: - Streams (Public Access)
+    let videoStream: AsyncStream<FrameReceivingEvents>
+    let advertisingStream: AsyncStream<AdvertiserEvents>
+    let modeSelectionStream: AsyncStream<ModeSelectionEvents>
+    let remoteConnectedViewStream: AsyncStream<RemoteConnectedViewEvents>
+    let remoteCaptureViewStream: AsyncStream<RemoteCaptureViewEvents>
+    let streamingStoreStream: AsyncStream<StreamingStoreEvents>
+    let rootStream: AsyncStream<RootEvents>
+
+    init() {
+        (videoStream, videoContinuation) = AsyncStream.makeStream(
+            of: FrameReceivingEvents.self,
+            bufferingPolicy: .bufferingNewest(1)
+        )
+        (advertisingStream, advertisingContinuation) = AsyncStream.makeStream(of: AdvertiserEvents.self)
+        (modeSelectionStream, modeSelectionContinuation) = AsyncStream.makeStream(of: ModeSelectionEvents.self)
+        (remoteConnectedViewStream, remoteConnectedViewContinuation) = AsyncStream.makeStream(
+            of: RemoteConnectedViewEvents.self
+        )
+        (remoteCaptureViewStream, remoteCaptureViewContinuation) = AsyncStream.makeStream(
+            of: RemoteCaptureViewEvents.self
+        )
+        (streamingStoreStream, streamingStoreContinuation) = AsyncStream.makeStream(of: StreamingStoreEvents.self)
+        (rootStream, rootContinuation) = AsyncStream.makeStream(of: RootEvents.self)
+    }
+
+    // MARK: - Yield Methods
+    func yieldVideoData(_ data: Data) {
+        videoContinuation.yield(.streamDataReceived(data))
+    }
+
+    func yieldAdvertisingEvent(_ event: AdvertiserEvents) {
+        advertisingContinuation.yield(event)
+    }
+
+    func yieldModeSelectionEvent(_ event: ModeSelectionEvents) {
+        modeSelectionContinuation.yield(event)
+    }
+
+    func yieldRemoteConnectedViewEvent(_ event: RemoteConnectedViewEvents) {
+        remoteConnectedViewContinuation.yield(event)
+    }
+
+    func yieldRemoteCaptureViewEvent(_ event: RemoteCaptureViewEvents) {
+        remoteCaptureViewContinuation.yield(event)
+    }
+
+    func yieldStreamingStoreEvent(_ event: StreamingStoreEvents) {
+        streamingStoreContinuation.yield(event)
+    }
+
+    func yieldRootEvent(_ event: RootEvents) {
+        rootContinuation.yield(event)
+    }
+}

--- a/mirroringBooth/mirroringBoothTests/AdvertiserTests.swift
+++ b/mirroringBooth/mirroringBoothTests/AdvertiserTests.swift
@@ -253,7 +253,7 @@ final class AdvertiserTests: XCTestCase {
 
 
         // WHEN
-        let commandAllStored = Browser.MirroringDeviceCommand.allPhotosStored.rawValue.data(using: .utf8)!
+        let commandAllStored = Browser.MirroringDeviceCommand.onStoreAllPhotos.rawValue.data(using: .utf8)!
         await advertiser.session(session, didReceive: commandAllStored, fromPeer: peerID)
 
         let commandUpdateCount = Browser.MirroringDeviceCommand.onUpdateCaptureCount.rawValue.data(using: .utf8)!

--- a/mirroringBooth/mirroringBoothTests/AdvertiserTests.swift
+++ b/mirroringBooth/mirroringBoothTests/AdvertiserTests.swift
@@ -320,7 +320,7 @@ final class AdvertiserTests: XCTestCase {
         )
 
         var capturedSession: MCSession?
-        advertiser.advertiser(
+        advertiser.connectionManager.advertiser(
             dummyAdvertiser,
             didReceiveInvitationFromPeer: peerID,
             withContext: context
@@ -344,7 +344,7 @@ final class AdvertiserTests: XCTestCase {
         )
 
         var capturedSession: MCSession?
-        advertiser.advertiser(
+        advertiser.connectionManager.advertiser(
             dummyAdvertiser,
             didReceiveInvitationFromPeer: peerID,
             withContext: context


### PR DESCRIPTION
## 🔗 연관된 이슈
- closed #283 

## 📝 작업 내용

### 📌 요약
- AdvertisingManager 객체 생성
- StreamManager 객체 생성
- AdvertiserCommandManager 객체 생성
- advertiser 적용

### 🔍 상세
- AdvertisingManager: 정말 Advertisng에 관련된 업무만 모으기 위한 객체입니다. MCNearbyServiceAdvertiser를 생성 및 관리하고, 그 Delegate를 여기 서구현합니다. 다만 기존 로직에서 세션을 invite를 수락하기 직전에 생성하도록 되어있었고, 이를 하위 객체에 전달하기 위해 delegate를 사용하였습니다.
- StreamManager: 지난 #272 작업으로 인해 생긴 continuation, AsyncStream을 관리하는 객체입니다. 단 외부에서 Advertiser 객체의 프로퍼티를 통해 stream에 접근하던 형태를 유지하기 위해 하위 객체인 Advertiser에서는 계산 프로퍼티로 접근할 수 있게 하였습니다.
- AdvertiserCommandManager: 명령어 관련 로직을 처리하는 객체입니다. 명령어 중 heartBeater, DeviceUseType을 처리하는 것이 있어 각각 weak, inout으로 처리하였습니다. 


## 📸 영상 / 이미지 (Optional)
기존 테스트 통과
<img width="293" height="274" alt="image" src="https://github.com/user-attachments/assets/ebda9c26-970a-42ba-baf5-4226e524316c" />
