### PR TITLE
[Refactor/#257] Browser의 제어 콜백을 AsyncStream으로 개선한다.  (#275 후속 작업)

### DIFF
--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/Browser.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/Browser.swift
@@ -65,9 +65,6 @@ final class Browser: NSObject {
 
     var onDeviceConnected: ((NearbyDevice) -> Void)?
 
-    /// 일괄 전송 시작 명령 수신 콜백
-    var onStartTransferCommand = PassthroughSubject<Void, Never>()
-
     /// 원격 모드 설정 명령 수신 콜백
     var onRemoteModeCommand: (() -> Void)?
 
@@ -440,7 +437,7 @@ extension Browser: MCSessionDelegate {
                 }
             case .startTransfer:
                 DispatchQueue.main.async {
-                    self.onStartTransferCommand.send()
+                    self.cameraStreamEventContinuation.yield(.startTransfer)
                     self.sendRemoteCommand(.navigateToRemoteComplete)
                 }
             case .setRemoteMode:

--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/Browser.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/Browser.swift
@@ -57,13 +57,12 @@ final class Browser: NSObject {
     /// 현재 연결 시도 중인 리모트 디바이스 ID
     private var targetRemoteDeviceID: String?
 
+    /// 현재 기기가 비디오 송신 역할인지 여부 (iPhone만 송신)
+    var isVideoSender: Bool {
+        UIDevice.current.userInterfaceIdiom == .phone
+    }
+
     let myDeviceName: String
-
-    var onDeviceFound: ((NearbyDevice) -> Void)?
-
-    var onDeviceLost: ((NearbyDevice) -> Void)?
-
-    var onDeviceConnected: ((NearbyDevice) -> Void)?
 
     /// 원격 모드 설정 명령 수신 콜백
     var onRemoteModeCommand: (() -> Void)?
@@ -74,11 +73,6 @@ final class Browser: NSObject {
     /// heartbeat 메시지 타임아웃
     var onHeartbeatTimeout: (() -> Void)?
     var onRemoteHeartbeatTimeout: (() -> Void)?
-
-    /// 현재 기기가 비디오 송신 역할인지 여부 (iPhone만 송신)
-    var isVideoSender: Bool {
-        UIDevice.current.userInterfaceIdiom == .phone
-    }
 
     /// 기기 검색 및 연결 전용 이벤트 스트림
     let browsingEventStream: AsyncStream<BrowsingEvents>
@@ -398,7 +392,7 @@ extension Browser: MCSessionDelegate {
 
         switch state {
         case .connected:
-            onDeviceConnected?(device)
+            browsingEventContinuation.yield(.deviceConnected(device))
 
         case .notConnected:
             browsingEventContinuation.yield(.deviceConnectionFailed)
@@ -501,9 +495,7 @@ extension Browser: MCNearbyServiceBrowserDelegate {
             state: .notConnected,
             type: deviceType
         )
-        DispatchQueue.main.async {
-            self.onDeviceFound?(device)
-        }
+        browsingEventContinuation.yield(.deviceFound(device))
     }
 
     func browser(_ browser: MCNearbyServiceBrowser,
@@ -516,8 +508,6 @@ extension Browser: MCNearbyServiceBrowserDelegate {
             state: .notConnected,
             type: deviceType
         )
-        DispatchQueue.main.async {
-            self.onDeviceLost?(device)
-        }
+        browsingEventContinuation.yield(.deviceLost(device))
     }
 }

--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/Browser.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/Browser.swift
@@ -70,10 +70,6 @@ final class Browser: NSObject {
     /// 타이머 모드 선택 명령 수신 콜백
     var onSelectedTimerModeCommand: (() -> Void)?
 
-    /// heartbeat 메시지 타임아웃
-    var onHeartbeatTimeout: (() -> Void)?
-    var onRemoteHeartbeatTimeout: (() -> Void)?
-
     /// 기기 검색 및 연결 전용 이벤트 스트림
     let browsingEventStream: AsyncStream<BrowsingEvents>
     private let browsingEventContinuation: AsyncStream<BrowsingEvents>.Continuation
@@ -81,6 +77,18 @@ final class Browser: NSObject {
     /// 카메라 촬영 및 전송 전용 이벤트 스트림
     let cameraStreamEventStream: AsyncStream<CameraStreamEvents>
     private let cameraStreamEventContinuation: AsyncStream<CameraStreamEvents>.Continuation
+
+    /// BrowsingStore 전용 Heartbeat 스트림
+    let browsingHeartbeatStream: AsyncStream<HeartBeatEvents>
+    let browsingHeartbeatContinuation: AsyncStream<HeartBeatEvents>.Continuation
+
+    /// ConnectionCheckStore 전용 Heartbeat 스트림
+    let connectionCheckHeartbeatStream: AsyncStream<HeartBeatEvents>
+    let connectionCheckHeartbeatContinuation: AsyncStream<HeartBeatEvents>.Continuation
+
+    /// CameraPreviewStore 전용 Heartbeat 스트림
+    let cameraPreviewHeartbeatStream: AsyncStream<HeartBeatEvents>
+    let cameraPreviewHeartbeatContinuation: AsyncStream<HeartBeatEvents>.Continuation
 
     init(serviceType: String = "mirroringbooth") {
         self.serviceType = serviceType
@@ -94,7 +102,23 @@ final class Browser: NSObject {
         )
 
         (self.cameraStreamEventStream, self.cameraStreamEventContinuation) = AsyncStream.makeStream(
-            of: CameraStreamEvents.self
+            of: CameraStreamEvents.self,
+            bufferingPolicy: .bufferingNewest(1)
+        )
+
+        (self.browsingHeartbeatStream, self.browsingHeartbeatContinuation) = AsyncStream.makeStream(
+            of: HeartBeatEvents.self,
+            bufferingPolicy: .bufferingNewest(1)
+        )
+
+        (self.connectionCheckHeartbeatStream, self.connectionCheckHeartbeatContinuation) = AsyncStream.makeStream(
+            of: HeartBeatEvents.self,
+            bufferingPolicy: .bufferingNewest(1)
+        )
+
+        (self.cameraPreviewHeartbeatStream, self.cameraPreviewHeartbeatContinuation) = AsyncStream.makeStream(
+            of: HeartBeatEvents.self,
+            bufferingPolicy: .bufferingNewest(1)
         )
 
         super.init()

--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/Browser.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/Browser.swift
@@ -57,11 +57,6 @@ final class Browser: NSObject {
     /// 현재 연결 시도 중인 리모트 디바이스 ID
     private var targetRemoteDeviceID: String?
 
-    /// 현재 기기가 비디오 송신 역할인지 여부 (iPhone만 송신)
-    var isVideoSender: Bool {
-        UIDevice.current.userInterfaceIdiom == .phone
-    }
-
     let myDeviceName: String
 
     /// 원격 모드 설정 명령 수신 콜백

--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowserEvents.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowserEvents.swift
@@ -13,10 +13,6 @@ enum BrowsingEvents {
     case deviceLost(NearbyDevice)
     case deviceConnected(NearbyDevice)
     case deviceConnectionFailed // 마이그레이션 완료
-
-    // Heartbeat
-    case heartbeatTimeout
-    case remoteHeartbeatTimeout
 }
 
 enum CameraStreamEvents {
@@ -24,7 +20,9 @@ enum CameraStreamEvents {
     case captureCommand // 마이그레이션 완료
     case sendPhoto // 마이그레이션 완료
     case startTransfer // 마이그레이션 완료
+}
 
+enum HeartBeatEvents {
     // Heartbeat
     case heartbeatTimeout
     case remoteHeartbeatTimeout

--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowserEvents.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowserEvents.swift
@@ -27,6 +27,7 @@ enum CameraStreamEvents {
     // 촬영
     case captureCommand // 마이그레이션 완료
     case sendPhoto // 마이그레이션 완료
+    case startTransfer // 마이그레이션 완료
 
     // Heartbeat
     case heartbeatTimeout

--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowserEvents.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowserEvents.swift
@@ -14,10 +14,6 @@ enum BrowsingEvents {
     case deviceConnected(NearbyDevice)
     case deviceConnectionFailed // 마이그레이션 완료
 
-    // 리모트 모드
-    case remoteModeCommand
-    case selectedTimerModeCommand
-
     // Heartbeat
     case heartbeatTimeout
     case remoteHeartbeatTimeout

--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowserEvents.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowserEvents.swift
@@ -12,14 +12,14 @@ enum BrowsingEvents {
     case deviceFound(NearbyDevice)
     case deviceLost(NearbyDevice)
     case deviceConnected(NearbyDevice)
-    case deviceConnectionFailed // 마이그레이션 완료
+    case deviceConnectionFailed
 }
 
 enum CameraStreamEvents {
     // 촬영
-    case captureCommand // 마이그레이션 완료
-    case sendPhoto // 마이그레이션 완료
-    case startTransfer // 마이그레이션 완료
+    case captureCommand
+    case sendPhoto
+    case startTransfer
 }
 
 enum HeartBeatEvents {

--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowsingStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowsingStore.swift
@@ -207,27 +207,24 @@ final class BrowsingStore: StoreProtocol {
         return []
     }
 
-    @MainActor
-    private func handleBrowserEvent(_ event: BrowsingEvents) {
+    private func handleBrowserEvent(_ event: BrowsingEvents) -> [Result] {
         switch event {
         case .deviceConnectionFailed:
-            reduce(.setIsConnecting(false))
+            return [.setIsConnecting(false)]
         case .deviceFound(let device):
-            reduce(.addDiscoveredDevice(device))
+            return [.addDiscoveredDevice(device)]
         case .deviceLost(let device):
-            reduce(.removeDiscoveredDevice(device))
             if device == state.mirroringDevice {
-                reduce(.setCurrentTarget(.mirroring))
+                return [.removeDiscoveredDevice(device), .setCurrentTarget(.mirroring)]
             }
+            return [.removeDiscoveredDevice(device)]
         case .deviceConnected(let device):
             switch state.currentTarget {
             case .mirroring:
-                reduce(.setMirroringDevice(device))
-                reduce(.setCurrentTarget(.remote))
+                return [.setMirroringDevice(device), .setCurrentTarget(.remote), .setIsConnecting(false)]
             case .remote:
-                reduce(.setRemoteDevice(device))
+                return [.setRemoteDevice(device), .setIsConnecting(false)]
             }
-            reduce(.setIsConnecting(false))
         }
     }
 

--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowsingStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowsingStore.swift
@@ -207,6 +207,7 @@ final class BrowsingStore: StoreProtocol {
         return []
     }
 
+    @MainActor
     private func handleBrowserEvent(_ event: BrowsingEvents) {
         switch event {
         case .deviceConnectionFailed:

--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowsingStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowsingStore.swift
@@ -247,7 +247,6 @@ final class BrowsingStore: StoreProtocol {
         return []
     }
 
-    // View에서 전달받은 BrowsingEvents를 처리하여 Result로 변환합니다.
     private func handleBrowserEvent(_ event: BrowsingEvents) -> [Result] {
         switch event {
         case .deviceConnectionFailed:

--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowsingStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowsingStore.swift
@@ -69,6 +69,7 @@ final class BrowsingStore: StoreProtocol {
 
     private(set) var state: State = .init()
     private var cancellables = Set<AnyCancellable>()
+    private var heartbeatTask: Task<Void, Never>?
 
     let browser: Browser
     let watchConnectionManager: WatchConnectionManager
@@ -83,6 +84,11 @@ final class BrowsingStore: StoreProtocol {
 
         setupBrowser()
         setupWatchConnectionManager()
+        setupHeartbeatListener()
+    }
+
+    deinit {
+        heartbeatTask?.cancel()
     }
 
     private func setupBrowser() {
@@ -97,21 +103,6 @@ final class BrowsingStore: StoreProtocol {
                     self?.watchConnectionManager.sendDisconnectionNotification()
                 }
                 self?.reduce(.setRemoteDevice(nil))
-            }
-        }
-
-        // 미러링 기기 연결 끊긴 경우
-        browser.onHeartbeatTimeout = { [weak self] in
-            Task { @MainActor in
-                self?.reduce(.setMirroringDevice(nil))
-                self?.reduce(.setCurrentTarget(.mirroring))
-            }
-        }
-        // 리모트 기기 연결 끊긴 경우
-        browser.onRemoteHeartbeatTimeout = { [weak self] in
-            Task { @MainActor in
-                self?.reduce(.setRemoteDevice(nil))
-                self?.reduce(.setCurrentTarget(.remote))
             }
         }
     }
@@ -291,22 +282,22 @@ final class BrowsingStore: StoreProtocol {
     }
 }
 
-private extension BrowsingStore {
-    func clearDevices() -> [Result] {
-        var results: [Result] = []
-        if !browser.isMirroringSessionActive {
-            if let mirroringDevice = state.mirroringDevice {
-                results.append(.setMirroringDevice(nil))
-                results.append(.removeDiscoveredDevice(mirroringDevice))
+extension BrowsingStore {
+    private func setupHeartbeatListener() {
+        heartbeatTask = Task { [weak self] in
+            guard let self else { return }
+            for await event in browser.browsingHeartbeatStream {
+                await MainActor.run {
+                    switch event {
+                    case .heartbeatTimeout:
+                        self.reduce(.setMirroringDevice(nil))
+                        self.reduce(.setCurrentTarget(.mirroring))
+                    case .remoteHeartbeatTimeout:
+                        self.reduce(.setRemoteDevice(nil))
+                        self.reduce(.setCurrentTarget(.remote))
+                    }
+                }
             }
-            results.append(.setCurrentTarget(.mirroring))
-        } else if !browser.isRemoteSessionActive {
-            if let remoteDevice = state.remoteDevice {
-                results.append(.setRemoteDevice(nil))
-                results.append(.removeDiscoveredDevice(remoteDevice))
-            }
-            results.append(.setCurrentTarget(.remote))
         }
-        return results
     }
 }

--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowsingStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowsingStore.swift
@@ -144,7 +144,7 @@ final class BrowsingStore: StoreProtocol {
         case .entry:
             browser.startSearching()
             watchConnectionManager.start()
-            return [.startAnimation] + clearDevices()
+            return [.startAnimation]
 
         case .exit:
             browser.stopSearching()

--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowsingStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowsingStore.swift
@@ -130,13 +130,6 @@ final class BrowsingStore: StoreProtocol {
             }
         }
 
-        browser.onStartTransferCommand
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] in
-                self?.watchConnectionManager.sendCaptureComplete()
-            }
-            .store(in: &cancellables)
-
         // 미러링 기기 연결 끊긴 경우
         browser.onHeartbeatTimeout = { [weak self] in
             Task { @MainActor in

--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowsingStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowsingStore.swift
@@ -82,7 +82,6 @@ final class BrowsingStore: StoreProtocol {
         self.browser = browser
         self.watchConnectionManager = watchConnectionManager
 
-        setupBrowser()
         setupWatchConnectionManager()
         setupHeartbeatListener()
     }
@@ -91,7 +90,7 @@ final class BrowsingStore: StoreProtocol {
         heartbeatTask?.cancel()
     }
 
-    private func setupBrowser() {
+    private func setupWatchConnectionManager() {
         browser.onRemoteModeCommand = { [weak self] in
             self?.watchConnectionManager.prepareWatchToCapture()
         }
@@ -105,9 +104,7 @@ final class BrowsingStore: StoreProtocol {
                 self?.reduce(.setRemoteDevice(nil))
             }
         }
-    }
 
-    private func setupWatchConnectionManager() {
         watchConnectionManager.onReachableChanged = { [weak self] isReachable in
             Task { @MainActor in
                 let watchDevice = NearbyDevice(

--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowsingStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowsingStore.swift
@@ -86,36 +86,6 @@ final class BrowsingStore: StoreProtocol {
     }
 
     private func setupBrowser() {
-        browser.onDeviceFound = { [weak self] device in
-            Task { @MainActor in
-                self?.reduce(.addDiscoveredDevice(device))
-            }
-        }
-
-        browser.onDeviceLost = { [weak self] device in
-            Task { @MainActor in
-                self?.reduce(.removeDiscoveredDevice(device))
-                if device == self?.state.mirroringDevice {
-                    self?.reduce(.setCurrentTarget(.mirroring))
-                }
-            }
-        }
-
-        browser.onDeviceConnected = { [weak self] device in
-            Task { @MainActor in
-                switch self?.state.currentTarget {
-                case .mirroring:
-                    self?.reduce(.setMirroringDevice(device))
-                    self?.reduce(.setCurrentTarget(.remote))
-                case .remote:
-                    self?.reduce(.setRemoteDevice(device))
-                case .none:
-                    break
-                }
-                self?.reduce(.setIsConnecting(false))
-            }
-        }
-
         browser.onRemoteModeCommand = { [weak self] in
             self?.watchConnectionManager.prepareWatchToCapture()
         }
@@ -243,16 +213,29 @@ final class BrowsingStore: StoreProtocol {
         case .browserEvent(let event):
             return handleBrowserEvent(event)
         }
-
         return []
     }
 
-    private func handleBrowserEvent(_ event: BrowsingEvents) -> [Result] {
+    private func handleBrowserEvent(_ event: BrowsingEvents) {
         switch event {
         case .deviceConnectionFailed:
-            return [.setIsConnecting(false)]
-        default:
-            return []
+            reduce(.setIsConnecting(false))
+        case .deviceFound(let device):
+            reduce(.addDiscoveredDevice(device))
+        case .deviceLost(let device):
+            reduce(.removeDiscoveredDevice(device))
+            if device == state.mirroringDevice {
+                reduce(.setCurrentTarget(.mirroring))
+            }
+        case .deviceConnected(let device):
+            switch state.currentTarget {
+            case .mirroring:
+                reduce(.setMirroringDevice(device))
+                reduce(.setCurrentTarget(.remote))
+            case .remote:
+                reduce(.setRemoteDevice(device))
+            }
+            reduce(.setIsConnecting(false))
         }
     }
 

--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowsingView.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowsingView.swift
@@ -45,8 +45,8 @@ struct BrowsingView: View {
                     store.state.discoveredDevices.isEmpty ?
                     "다른 기기에서 미러링/리모트 기기로 시작하기를 눌러주세요!" : store.state.currentTarget.searchDescription
                 )
-                    .font(.footnote)
-                    .foregroundStyle(Color(.secondaryLabel))
+                .font(.footnote)
+                .foregroundStyle(Color(.secondaryLabel))
 
                 // 발견된 기기 목록 (버튼)
                 ScrollView {
@@ -118,9 +118,7 @@ struct BrowsingView: View {
         }
         .onAppear {
             store.send(.entry)
-            if rootStore.browser == nil {
-                rootStore.browser = store.browser
-            }
+            rootStore.browser = store.browser
         }
         .onDisappear {
             store.send(.exit)

--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowsingView.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowsingView.swift
@@ -164,7 +164,9 @@ struct BrowsingView: View {
             isPresented: Binding(
                 get: { store.state.showToast },
                 set: { store.send(.showToast($0)) }
-        ), message: store.state.toastMessage)
+            ),
+            message: store.state.toastMessage
+        )
     }
 
     private func isDeviceSelected(_ device: NearbyDevice) -> DeviceUseType? {

--- a/mirroringBooth/mirroringBooth/Device/Camera/ConnectionCheck/ConnectionCheckStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/ConnectionCheck/ConnectionCheckStore.swift
@@ -39,6 +39,8 @@ final class ConnectionCheckStore: StoreProtocol {
     let cameraDevice: String
     let mirroringDevice: String
 
+    private var heartbeatTask: Task<Void, Never>?
+
     init(
         _ list: ConnectionList,
         _ browser: Browser
@@ -52,10 +54,14 @@ final class ConnectionCheckStore: StoreProtocol {
         }
     }
 
+    deinit {
+        heartbeatTask?.cancel()
+    }
+
     func action(_ intent: Intent) -> [Result] {
         switch intent {
         case .entry:
-            setupBrowser()
+            setupHeartbeatListener()
             return []
 
         case .onReadyToCapture:
@@ -103,17 +109,19 @@ final class ConnectionCheckStore: StoreProtocol {
 }
 
 extension ConnectionCheckStore {
-    private func setupBrowser() {
-        browser.onHeartbeatTimeout = { [weak self] in
-            Task { @MainActor in
-                self?.reduce(.setIsMirroringDisconnected(true))
-            }
-        }
-
-        browser.onRemoteHeartbeatTimeout = { [weak self] in
-            Task { @MainActor in
-                self?.reduce(.setShowRemoteDisconnectedAlert(true))
-                self?.reduce(.setRemoteDevice(nil))
+    private func setupHeartbeatListener() {
+        heartbeatTask = Task { [weak self] in
+            guard let self else { return }
+            for await event in browser.connectionCheckHeartbeatStream {
+                await MainActor.run {
+                    switch event {
+                    case .heartbeatTimeout:
+                        self.reduce(.setIsMirroringDisconnected(true))
+                    case .remoteHeartbeatTimeout:
+                        self.reduce(.setShowRemoteDisconnectedAlert(true))
+                        self.reduce(.setRemoteDevice(nil))
+                    }
+                }
             }
         }
     }

--- a/mirroringBooth/mirroringBooth/Device/Camera/Streaming/CameraManager/CameraManager.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Streaming/CameraManager/CameraManager.swift
@@ -235,7 +235,9 @@ extension CameraManager: AVCaptureVideoDataOutputSampleBufferDelegate {
         from connection: AVCaptureConnection
     ) {
         // 프레임 캡처 성공
-        rawData?(sampleBuffer)
+        DispatchQueue.main.async { [weak self] in
+            self?.rawData?(sampleBuffer)
+        }
         encoder.encode(sampleBuffer)
     }
 

--- a/mirroringBooth/mirroringBooth/Device/Camera/Streaming/CameraPreview.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Streaming/CameraPreview.swift
@@ -71,7 +71,6 @@ struct CameraPreview: View {
             withAnimation(.linear(duration: 0.8).repeatForever(autoreverses: true)) {
                 store.send(.entry(withAngle: UIDevice.current.orientation.rawValue))
             }
-            store.send(.startSession)
             store.send(.updateAngle(rawValue: UIDevice.current.orientation.rawValue))
         }
         .onDisappear {

--- a/mirroringBooth/mirroringBooth/Device/Camera/Streaming/CameraPreview.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Streaming/CameraPreview.swift
@@ -71,7 +71,6 @@ struct CameraPreview: View {
             withAnimation(.linear(duration: 0.8).repeatForever(autoreverses: true)) {
                 store.send(.entry(withAngle: UIDevice.current.orientation.rawValue))
             }
-            store.send(.updateAngle(rawValue: UIDevice.current.orientation.rawValue))
         }
         .onDisappear {
             store.send(.exit)

--- a/mirroringBooth/mirroringBooth/Device/Camera/Streaming/CameraPreview.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Streaming/CameraPreview.swift
@@ -71,14 +71,8 @@ struct CameraPreview: View {
             withAnimation(.linear(duration: 0.8).repeatForever(autoreverses: true)) {
                 store.send(.entry(withAngle: UIDevice.current.orientation.rawValue))
             }
-
-            rootStore.browser?.onHeartbeatTimeout = { [weak store, weak rootStore] in
-                store?.send(.isMirroringDisconnected)
-                rootStore?.browser?.disconnect(useType: .remote)
-            }
-            rootStore.browser?.onRemoteHeartbeatTimeout = { [weak rootStore] in
-                rootStore?.browser?.sendCommand(.switchSelectModeView)
-            }
+            store.send(.startSession)
+            store.send(.updateAngle(rawValue: UIDevice.current.orientation.rawValue))
         }
         .onDisappear {
             store.send(.exit)

--- a/mirroringBooth/mirroringBooth/Device/Camera/Streaming/CameraPreviewStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Streaming/CameraPreviewStore.swift
@@ -118,7 +118,6 @@ final class CameraPreviewStore: StoreProtocol {
         case .isMirroringDisconnected:
             state.isMirroringDisconnected = true
         }
-
         self.state = state
     }
 
@@ -130,6 +129,9 @@ final class CameraPreviewStore: StoreProtocol {
         case .captureCommand:
             cameraManager.capturePhoto(getOrientationByAngle(state.angle))
             return []
+        case .startTransfer:
+            cameraManager.sendAllPhotos(using: browser)
+            return [.setIsTransferring(true)]
         default:
             return []
         }
@@ -149,19 +151,7 @@ private extension CameraPreviewStore {
             framedData.append(data)
 
             self.browser.sendStreamData(framedData)
-        }
-        
-        // 일괄 전송 시작 명령 수신
-        browser.onStartTransferCommand
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] in
-                guard let self = self else { return }
-                Task { @MainActor in
-                    self.reduce(.setIsTransferring(true))
-                }
-                self.cameraManager.sendAllPhotos(using: self.browser)
-            }
-            .store(in: &cancellables)
+        }   
 
         // 전송 완료
         cameraManager.onTransferCompleted = { [weak self] in

--- a/mirroringBooth/mirroringBooth/Device/Camera/Streaming/CameraPreviewStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Streaming/CameraPreviewStore.swift
@@ -127,19 +127,6 @@ final class CameraPreviewStore: StoreProtocol {
         }
         self.state = state
     }
-
-    private func handleBrowserEvent(_ event: CameraStreamEvents) -> [Result] {
-        switch event {
-        case .sendPhoto:
-            return [.setTransferCount(state.transfercount + 1)]
-        case .captureCommand:
-            cameraManager.capturePhoto(getOrientationByAngle(state.angle))
-            return []
-        case .startTransfer:
-            cameraManager.sendAllPhotos(using: browser)
-            return [.setIsTransferring(true)]
-        }
-    }
 }
 
 private extension CameraPreviewStore {
@@ -207,6 +194,19 @@ extension CameraPreviewStore {
                     }
                 }
             }
+        }
+    }
+
+    private func handleBrowserEvent(_ event: CameraStreamEvents) -> [Result] {
+        switch event {
+        case .sendPhoto:
+            return [.setTransferCount(state.transfercount + 1)]
+        case .captureCommand:
+            cameraManager.capturePhoto(getOrientationByAngle(state.angle))
+            return []
+        case .startTransfer:
+            cameraManager.sendAllPhotos(using: browser)
+            return [.setIsTransferring(true)]
         }
     }
 }

--- a/mirroringBooth/mirroringBooth/Device/Camera/Streaming/CameraPreviewStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Streaming/CameraPreviewStore.swift
@@ -48,6 +48,7 @@ final class CameraPreviewStore: StoreProtocol {
     private let browser: Browser
     private let cameraManager: CameraManageable
     private var cancellables = Set<AnyCancellable>()
+    private var heartbeatTask: Task<Void, Never>?
 
     var eventStream: AsyncStream<CameraStreamEvents> {
         browser.cameraStreamEventStream
@@ -61,6 +62,12 @@ final class CameraPreviewStore: StoreProtocol {
         self.browser = browser
         self.cameraManager = manager
         self.state = State(deviceName: deviceName)
+
+        setupHeartbeatListener()
+    }
+
+    deinit {
+        heartbeatTask?.cancel()
     }
 
     func action(_ intent: Intent) -> [Result] {
@@ -181,6 +188,25 @@ private extension CameraPreviewStore {
         case -90: return .landscapeLeft
         case 90: return .landscapeRight
         default: return .portrait
+        }
+    }
+}
+
+extension CameraPreviewStore {
+    private func setupHeartbeatListener() {
+        heartbeatTask = Task { [weak self] in
+            guard let self else { return }
+            for await event in browser.cameraPreviewHeartbeatStream {
+                await MainActor.run {
+                    switch event {
+                    case .heartbeatTimeout:
+                        self.send(.isMirroringDisconnected)
+                        self.browser.disconnect(useType: .remote)
+                    case .remoteHeartbeatTimeout:
+                        self.browser.sendCommand(.switchSelectModeView)
+                    }
+                }
+            }
         }
     }
 }

--- a/mirroringBooth/mirroringBooth/Device/Camera/Streaming/CameraPreviewStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Streaming/CameraPreviewStore.swift
@@ -131,8 +131,6 @@ final class CameraPreviewStore: StoreProtocol {
         case .startTransfer:
             cameraManager.sendAllPhotos(using: browser)
             return [.setIsTransferring(true)]
-        default:
-            return []
         }
     }
 }

--- a/mirroringBooth/mirroringBooth/Device/Camera/Streaming/CameraPreviewStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Streaming/CameraPreviewStore.swift
@@ -121,7 +121,6 @@ final class CameraPreviewStore: StoreProtocol {
         self.state = state
     }
 
-    // View에서 전달받은 CameraStreamEvents를 처리하여 Result로 변환합니다.
     private func handleBrowserEvent(_ event: CameraStreamEvents) -> [Result] {
         switch event {
         case .sendPhoto:

--- a/mirroringBooth/mirroringBooth/Device/Common/HeartBeater/Browser+HeartBeater.swift
+++ b/mirroringBooth/mirroringBooth/Device/Common/HeartBeater/Browser+HeartBeater.swift
@@ -17,13 +17,13 @@ extension Browser: HeartBeaterDelegate {
 
     func onTimeout(_ sender: HeartBeater) {
         if sender === mirroringHeartBeater {
-            DispatchQueue.main.async {
-                self.onHeartbeatTimeout?()
-            }
+            browsingHeartbeatContinuation.yield(.heartbeatTimeout)
+            connectionCheckHeartbeatContinuation.yield(.heartbeatTimeout)
+            cameraPreviewHeartbeatContinuation.yield(.heartbeatTimeout)
         } else if sender === remoteHeartBeater {
-            DispatchQueue.main.async {
-                self.onRemoteHeartbeatTimeout?()
-            }
+            browsingHeartbeatContinuation.yield(.remoteHeartbeatTimeout)
+            connectionCheckHeartbeatContinuation.yield(.remoteHeartbeatTimeout)
+            cameraPreviewHeartbeatContinuation.yield(.remoteHeartbeatTimeout)
         }
     }
 }


### PR DESCRIPTION
## 🔗 연관된 이슈
> closed #257

## 📝 작업 내용

### 📌 요약
기존 클로저 기반으로 작성되어 있던 `Browser`의 이벤트 처리 로직을  `AsyncStream`으로 마이그레이션했습니다. 

### 🔍 상세

#### 1. 마이그레이션 현황

`Browser` 클래스에 정의된 콜백을 `AsyncStream`으로 변환했습니다.

| 이벤트 | 기존 | 변경 후 | 마이그레이션 완료 |
| :--- | :--- | :--- | :---: |
| `onDeviceFound` | 클로저 | AsyncStream | ✅ |
| `onDeviceLost` | 클로저 | AsyncStream | ✅ |
| `onDeviceConnected` | 클로저 | AsyncStream | ✅ |
| `onDeviceConnectionFailed` | 클로저 | AsyncStream | ✅ |
| `onCaptureCommand` | 클로저 | AsyncStream | ✅ |
| `onSendPhoto` | 클로저 | AsyncStream | ✅ |
| `onHeartbeatTimeout` | 클로저 | AsyncStream | ✅ |
| `onRemoteHeartbeatTimeout` | 클로저 | AsyncStream | ✅ |
| `onRemoteModeCommand` | 클로저 | 클로저 | ❌ |
| `onSelectedTimerModeCommand` | 클로저 | 클로저 | ❌ |
| `onStartTransferCommand` | Combine | AsyncStream | ✅ |

> `onRemoteModeCommand`와 `onSelectedTimerModeCommand`는 `BrowsingStore` 및 `WatchConnectionManager`와의 의존성 결합도가 높아, 이번 마이그레이션 범위에서 제외하고 기존 방식을 유지했습니다.  
> 해당 콜백들의 AsyncStream 마이그레이션은 Browser 분리 작업 및 디버깅 작업이 끝나면 바로 이어서 작업하겠습니다.

#### 2. 스트림 분리 및 버퍼 정책 (Buffering Policy)

Browser에서는 `AsyncStream`의 특성(단일 소비자)과 이벤트의 중요도에 따라 스트림을 분리하고 버퍼 정책을 다르게 가져갔습니다.

*   **기본 이벤트 (`deviceFound`, `captureCommand` 등)**: `.unbounded`
    *   기기 검색이나 촬영 명령 등은 단 하나라도 유실되어서는 안 되는 핵심 이벤트라고 생각했습니다.
    *   이벤트 발생 즉시 `for await` 루프에서 소비되므로, 메모리에 무한정 쌓일 가능성이 희박하다고 생각해 기본값 `.unbounded`를 사용했습니다.
*   **Heartbeat 이벤트 (`heartBeatStream`)**: `.bufferingNewest(1)`
    *   하트비트 타임아웃은 `현재 연결이 끊겼는가?`하는 최신 상태가 가장 중요하다고 생각했습니다.
    *   따라서 버퍼 크기를 1로 제한하고 최신 이벤트만 유지하여 혹시 모를 메모리 누수를 방지했습니다.

## 💬 리뷰 노트
### 🤔 AsyncStream 마이그레이션 후기 및 장점
기존 클로저 콜백 방식에서 `AsyncStream`으로 변경하며 느낀 장점은 다음과 같습니다.
1.  **명확한 생명주기**
   - `Task`와 `for await`을 사용함으로써 뷰나 스토어가 해제될 때 구독도 자동으로 취소되는 흐름이 자연스럽게 다가왔습니다.
2. **응집도 상승**
   - `setupBrowser()` 같은 함수에 콜백 할당이 산재되어 있던 이전과 달리 `task` 내부에서 이벤트 종류별(`switch case`)로 로직을 한눈에 파악할 수 있어 가독성 측면에서 좋아졌다고 생각이 듭니다..ㅎ

### 🧪 테스트
- 현재 Xcode 자체적으로 계속 오류가 발생하여.. 테스트 코드를 집어넣지 못하고 있는 상황입니다...😭
   - 다음 작업으로 Xcode를 재설치하거나 무슨 방법을 써서라도 테스트 코드를 가급적 빨리 집어넣겠습니다.
   - 그 후 테스트코드가 뽑힌 직후 바로 Browser 분리를 진행할 예정입니다.