### PR TITLE
[test/#288] Browser의 테스트 코드를 작성한다.

### DIFF
--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/Browser.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/Browser.swift
@@ -57,6 +57,11 @@ final class Browser: NSObject {
     /// 현재 연결 시도 중인 리모트 디바이스 ID
     private var targetRemoteDeviceID: String?
 
+    /// 현재 기기가 비디오 송신 역할인지 여부 (iPhone만 송신)
+    var isVideoSender: Bool {
+        UIDevice.current.userInterfaceIdiom == .phone
+    }
+
     let myDeviceName: String
 
     /// 원격 모드 설정 명령 수신 콜백

--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowsingStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowsingStore.swift
@@ -201,10 +201,11 @@ final class BrowsingStore: StoreProtocol {
         case .browserEvent(let event):
             return handleBrowserEvent(event)
         }
+
         return []
     }
 
-    private func handleBrowserEvent(_ event: BrowsingEvents) -> [Result] {
+    private func handleBrowserEvent(_ event: BrowsingEvents) {
         switch event {
         case .deviceConnectionFailed:
             return [.setIsConnecting(false)]

--- a/mirroringBooth/mirroringBooth/Device/Camera/ConnectionCheck/ConnectionCheckStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/ConnectionCheck/ConnectionCheckStore.swift
@@ -41,6 +41,8 @@ final class ConnectionCheckStore: StoreProtocol {
 
     private var heartbeatTask: Task<Void, Never>?
 
+    private var heartbeatTask: Task<Void, Never>?
+
     init(
         _ list: ConnectionList,
         _ browser: Browser
@@ -52,6 +54,10 @@ final class ConnectionCheckStore: StoreProtocol {
         Task { @MainActor in
             reduce(.setRemoteDevice(list.remoteName))
         }
+    }
+
+    deinit {
+        heartbeatTask?.cancel()
     }
 
     deinit {

--- a/mirroringBooth/mirroringBooth/Device/Camera/Streaming/CameraPreviewStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Streaming/CameraPreviewStore.swift
@@ -125,6 +125,7 @@ final class CameraPreviewStore: StoreProtocol {
         case .isMirroringDisconnected:
             state.isMirroringDisconnected = true
         }
+
         self.state = state
     }
 }

--- a/mirroringBooth/mirroringBoothTests/BrowserTests.swift
+++ b/mirroringBooth/mirroringBoothTests/BrowserTests.swift
@@ -126,50 +126,10 @@ struct BrowserTests {
         }
     }
 
-    // MARK: - 3. 명령 수신 테스트 (executeCommand)
+    // TODO: executeCommand는 현재 private이므로 리팩터링 후 BrowserCommandManager를 통해 명령 수신 테스트 진행 예정
+    // TODO: MCSession 의존성 주입이 필요하므로 리팩터링 후 연결 상태 변경(deviceConnected, deviceConnectionFailed) 테스트 진행 예정
+    // TODO: sendPhotoResource 완료 이벤트(.sendPhoto)는 실제 MCSession.sendResource 콜백이 필요하므로 리팩터링 후 테스트 진행 예정
 
-    @Test func capturePhoto_명령을_수신하면_captureCommand_이벤트가_발생한다() async {
-        // GIVEN
-        let (browser, collector) = makeSUT()
-        await collector.startCollecting(streamType: .cameraStream)
-
-        // 명령 데이터 생성
-        let commandData = Advertiser.CameraDeviceCommand.capturePhoto.rawValue.data(using: .utf8)!
-
-        // 더미 세션 생성 (내부 mirroringCommandSession 또는 remoteSession 시뮬레이션 필요)
-        // Note: Browser의 executeCommand는 private이므로, didReceive를 통해 호출해야 함
-        // 하지만 session이 nil이면 처리되지 않음. 이 부분은 통합 테스트 또는 리팩터링 후 테스트 가능
-
-        // WHEN - 직접 capturePhoto 호출로 대체 (명령 수신 시 내부적으로 capturePhoto가 호출됨)
-        // 리팩터링 후에는 BrowserCommandManager를 통해 테스트 가능
-        await MainActor.run {
-            browser.capturePhoto()
-        }
-
-        // THEN
-        let events = await collector.collectCameraStreamEvents(count: 1, timeout: 0.5)
-        #expect(events.count >= 1)
-        #expect(events.contains { event in
-            if case .captureCommand = event { return true }
-            return false
-        })
-    }
-
-    @Test func startTransfer_명령을_수신하면_startTransfer_이벤트가_발생한다() async {
-        // GIVEN
-        let (browser, collector) = makeSUT()
-        await collector.startCollecting(streamType: .cameraStream)
-
-        // Note: executeCommand는 private이므로 직접 테스트 불가
-        // 리팩터링 후 BrowserCommandManager를 통해 public하게 테스트 가능
-        // 현재는 통합 시나리오로 검증
-
-        // 임시: cameraStreamEventContinuation에 직접 접근 불가하므로 스킵
-        // 리팩터링 시 yield 메서드를 통해 접근 가능하게 변경 필요
-
-        // THEN - 이 테스트는 리팩터링 후 활성화
-        #expect(true, "리팩터링 후 BrowserCommandManager를 통해 테스트")
-    }
 
     // MARK: - 4. 명령 전송 (세션 없을 때 안전성)
 

--- a/mirroringBooth/mirroringBoothTests/BrowserTests.swift
+++ b/mirroringBooth/mirroringBoothTests/BrowserTests.swift
@@ -10,20 +10,16 @@ import MultipeerConnectivity
 @testable import mirroringBooth
 
 // MARK: - Browser Tests
-// 우선순위:
-// 1. 이벤트 스트림 방출 (browsingEventStream, cameraStreamEventStream) - 핵심 출력
-// 2. 명령 수신/처리 (executeCommand) - 핵심 입력
-// 3. 연결 상태 변경 - 세션 관리
-
+/// AI를 활용해 작성했습니다.
+@MainActor
 struct BrowserTests {
-
-    // MARK: - SUT Factory
-
-    /// System Under Test (SUT) 생성 헬퍼
-    /// 테스트에서 Browser 인스턴스와 관련 이벤트 수집기를 함께 생성
+    
     private func makeSUT() -> (browser: Browser, eventCollector: EventCollector) {
         let browser = Browser()
-        let collector = EventCollector(browser: browser)
+        let collector = EventCollector(
+            browsingStream: browser.browsingEventStream,
+            cameraStream: browser.cameraStreamEventStream
+        )
         return (browser, collector)
     }
 
@@ -32,7 +28,7 @@ struct BrowserTests {
     @Test func 주변_기기를_발견하면_deviceFound_이벤트가_발생한다() async {
         // GIVEN
         let (browser, collector) = makeSUT()
-        let testPeerID = MCPeerID(displayName: "TestPeer")
+        let testPeerID = MCPeerID(displayName: "몽이")
         let discoveryInfo = ["deviceType": "iPad"]
 
         await collector.startCollecting(streamType: .browsing)
@@ -51,17 +47,17 @@ struct BrowserTests {
             Issue.record("Expected .deviceFound event, got: \(String(describing: events.first))")
             return
         }
-        #expect(device.id == "TestPeer")
+        #expect(device.id == "몽이")
         #expect(device.type == .iPad)
     }
 
     @Test func 주변_기기가_사라지면_deviceLost_이벤트가_발생한다() async {
         // GIVEN
         let (browser, collector) = makeSUT()
-        let testPeerID = MCPeerID(displayName: "TestPeer")
+        let testPeerID = MCPeerID(displayName: "몽이")
         let discoveryInfo = ["deviceType": "iPad"]
 
-        // 먼저 기기 발견 시뮬레이션
+        // 기기 발견 시뮬레이션
         browser.browser(
             MCNearbyServiceBrowser(peer: testPeerID, serviceType: "mirroringbooth"),
             foundPeer: testPeerID,
@@ -84,14 +80,14 @@ struct BrowserTests {
             Issue.record("Expected .deviceLost event, got: \(String(describing: events.first))")
             return
         }
-        #expect(device.id == "TestPeer")
+        #expect(device.id == "몽이")
     }
 
     @Test func deviceType이_없는_기기는_발견_이벤트가_발생하지_않는다() async {
         // GIVEN
         let (browser, collector) = makeSUT()
-        let testPeerID = MCPeerID(displayName: "TestPeer")
-        let emptyDiscoveryInfo: [String: String] = [:]  // deviceType 없음
+        let testPeerID = MCPeerID(displayName: "몽이")
+        let emptyDiscoveryInfo: [String: String] = [:]  // deviceType 없는 상태
 
         await collector.startCollecting(streamType: .browsing)
 
@@ -126,16 +122,20 @@ struct BrowserTests {
         }
     }
 
-    // TODO: executeCommand는 현재 private이므로 리팩터링 후 BrowserCommandManager를 통해 명령 수신 테스트 진행 예정
-    // TODO: MCSession 의존성 주입이 필요하므로 리팩터링 후 연결 상태 변경(deviceConnected, deviceConnectionFailed) 테스트 진행 예정
-    // TODO: sendPhotoResource 완료 이벤트(.sendPhoto)는 실제 MCSession.sendResource 콜백이 필요하므로 리팩터링 후 테스트 진행 예정
+    // executeCommand는 현재 private이므로 리팩터링 후
+    // BrowserCommandManager를 통해 명령 수신 테스트 진행 예정입니다.
 
+    // MCSession 의존성 주입이 필요하므로 리팩터링 후
+    // 연결 상태 변경(deviceConnected, deviceConnectionFailed) 테스트 진행 예정입니다.
+
+    // sendPhotoResource 완료 이벤트(.sendPhoto)는
+    // 실제 MCSession.sendResource 콜백이 필요하므로 리팩터링 후 테스트 진행 예정
 
     // MARK: - 4. 명령 전송 (세션 없을 때 안전성)
 
     @Test func 세션이_없을때_sendCommand는_실패해도_크래시하지_않는다() async {
         // GIVEN
-        let browser = Browser()
+        let (browser, _) = makeSUT()
 
         // WHEN - mirroringCommandSession이 nil인 상태
         browser.sendCommand(.heartBeat)
@@ -146,7 +146,7 @@ struct BrowserTests {
 
     @Test func 세션이_없을때_sendRemoteCommand는_실패해도_크래시하지_않는다() async {
         // GIVEN
-        let browser = Browser()
+        let (browser, _) = makeSUT()
 
         // WHEN - remoteSession이 nil인 상태
         browser.sendRemoteCommand(.heartBeat)
@@ -157,7 +157,7 @@ struct BrowserTests {
 
     @Test func 세션이_없을때_sendStreamData는_실패해도_크래시하지_않는다() async {
         // GIVEN
-        let browser = Browser()
+        let (browser, _) = makeSUT()
         let testData = Data([0x01, 0x02, 0x03])
 
         // WHEN - mirroringSession이 nil인 상태
@@ -171,7 +171,7 @@ struct BrowserTests {
 
     @Test func startSearching_호출시_크래시하지_않는다() async {
         // GIVEN
-        let browser = Browser()
+        let (browser, _) = makeSUT()
 
         // WHEN
         browser.startSearching()
@@ -185,7 +185,7 @@ struct BrowserTests {
 
     @Test func disconnect_호출시_크래시하지_않는다() async {
         // GIVEN
-        let browser = Browser()
+        let (browser, _) = makeSUT()
 
         // WHEN
         browser.disconnect()
@@ -205,14 +205,19 @@ actor EventCollector {
         case cameraStream
     }
 
-    private let browser: Browser
+    private let browsingStream: AsyncStream<BrowsingEvents>
+    private let cameraStream: AsyncStream<CameraStreamEvents>
     private var browsingEvents: [BrowsingEvents] = []
     private var cameraStreamEvents: [CameraStreamEvents] = []
     private var browsingTask: Task<Void, Never>?
     private var cameraStreamTask: Task<Void, Never>?
 
-    init(browser: Browser) {
-        self.browser = browser
+    init(
+        browsingStream: AsyncStream<BrowsingEvents>,
+        cameraStream: AsyncStream<CameraStreamEvents>
+    ) {
+        self.browsingStream = browsingStream
+        self.cameraStream = cameraStream
     }
 
     deinit {
@@ -227,7 +232,7 @@ actor EventCollector {
             browsingTask = Task { [weak self] in
                 guard let self else { return }
                 var skipped = 0
-                for await event in browser.browsingEventStream {
+                for await event in browsingStream {
                     if skipped < skipFirst {
                         skipped += 1
                         continue
@@ -238,7 +243,7 @@ actor EventCollector {
         case .cameraStream:
             cameraStreamTask = Task { [weak self] in
                 guard let self else { return }
-                for await event in browser.cameraStreamEventStream {
+                for await event in cameraStream {
                     await self.appendCameraStreamEvent(event)
                 }
             }

--- a/mirroringBooth/mirroringBoothTests/BrowserTests.swift
+++ b/mirroringBooth/mirroringBoothTests/BrowserTests.swift
@@ -10,29 +10,32 @@ import MultipeerConnectivity
 @testable import mirroringBooth
 
 // MARK: - Browser Tests
+// 우선순위:
+// 1. 이벤트 스트림 방출 (browsingEventStream, cameraStreamEventStream) - 핵심 출력
+// 2. 명령 수신/처리 (executeCommand) - 핵심 입력
+// 3. 연결 상태 변경 - 세션 관리
 
 struct BrowserTests {
 
-    // MARK: - 기기 검색 (Discovery) 테스트
+    // MARK: - SUT Factory
+
+    /// System Under Test (SUT) 생성 헬퍼
+    /// 테스트에서 Browser 인스턴스와 관련 이벤트 수집기를 함께 생성
+    private func makeSUT() -> (browser: Browser, eventCollector: EventCollector) {
+        let browser = Browser()
+        let collector = EventCollector(browser: browser)
+        return (browser, collector)
+    }
+
+    // MARK: - 1. 기기 검색 (Discovery) 이벤트 테스트
 
     @Test func 주변_기기를_발견하면_deviceFound_이벤트가_발생한다() async {
         // GIVEN
-        let browser = Browser()
+        let (browser, collector) = makeSUT()
         let testPeerID = MCPeerID(displayName: "TestPeer")
         let discoveryInfo = ["deviceType": "iPad"]
 
-        // Event 수신 Task 준비
-        let expectation = Expectation<BrowsingEvents?>()
-        let eventTask = Task {
-            for await event in browser.browsingEventStream {
-                expectation.fulfill(with: event)
-                break
-            }
-        }
-        defer { eventTask.cancel() }
-
-        // 구독 준비 시간
-        try? await Task.sleep(nanoseconds: 50_000_000)
+        await collector.startCollecting(streamType: .browsing)
 
         // WHEN
         browser.browser(
@@ -42,9 +45,10 @@ struct BrowserTests {
         )
 
         // THEN
-        let result = await expectation.value
-        guard case .deviceFound(let device) = result else {
-            Issue.record("Expected .deviceFound event")
+        let events = await collector.collectBrowsingEvents(count: 1, timeout: 0.5)
+        #expect(events.count == 1)
+        guard case .deviceFound(let device) = events.first else {
+            Issue.record("Expected .deviceFound event, got: \(String(describing: events.first))")
             return
         }
         #expect(device.id == "TestPeer")
@@ -53,33 +57,19 @@ struct BrowserTests {
 
     @Test func 주변_기기가_사라지면_deviceLost_이벤트가_발생한다() async {
         // GIVEN
-        let browser = Browser()
+        let (browser, collector) = makeSUT()
         let testPeerID = MCPeerID(displayName: "TestPeer")
         let discoveryInfo = ["deviceType": "iPad"]
 
-        // 먼저 기기 발견
+        // 먼저 기기 발견 시뮬레이션
         browser.browser(
             MCNearbyServiceBrowser(peer: testPeerID, serviceType: "mirroringbooth"),
             foundPeer: testPeerID,
             withDiscoveryInfo: discoveryInfo
         )
 
-        // 스트림 clean up
-        _ = Task {
-            for await _ in browser.browsingEventStream { break }
-        }
-        try? await Task.sleep(nanoseconds: 50_000_000)
-
-        // Event 수신 Task 준비
-        let expectation = Expectation<BrowsingEvents?>()
-        let eventTask = Task {
-            for await event in browser.browsingEventStream {
-                expectation.fulfill(with: event)
-                break
-            }
-        }
-        defer { eventTask.cancel() }
-        try? await Task.sleep(nanoseconds: 50_000_000)
+        // 첫 번째 이벤트 소비 후 수집 시작
+        await collector.startCollecting(streamType: .browsing, skipFirst: 1)
 
         // WHEN
         browser.browser(
@@ -88,36 +78,179 @@ struct BrowserTests {
         )
 
         // THEN
-        let result = await expectation.value
-        guard case .deviceLost(let device) = result else {
-            Issue.record("Expected .deviceLost event")
+        let events = await collector.collectBrowsingEvents(count: 1, timeout: 0.5)
+        #expect(events.count == 1)
+        guard case .deviceLost(let device) = events.first else {
+            Issue.record("Expected .deviceLost event, got: \(String(describing: events.first))")
             return
         }
         #expect(device.id == "TestPeer")
     }
+
+    @Test func deviceType이_없는_기기는_발견_이벤트가_발생하지_않는다() async {
+        // GIVEN
+        let (browser, collector) = makeSUT()
+        let testPeerID = MCPeerID(displayName: "TestPeer")
+        let emptyDiscoveryInfo: [String: String] = [:]  // deviceType 없음
+
+        await collector.startCollecting(streamType: .browsing)
+
+        // WHEN
+        browser.browser(
+            MCNearbyServiceBrowser(peer: testPeerID, serviceType: "mirroringbooth"),
+            foundPeer: testPeerID,
+            withDiscoveryInfo: emptyDiscoveryInfo
+        )
+
+        // THEN
+        let events = await collector.collectBrowsingEvents(count: 1, timeout: 0.3)
+        #expect(events.isEmpty, "deviceType 없이 발견된 기기는 이벤트가 발생하지 않아야 함")
+    }
+
+    // MARK: - 2. 카메라 스트림 이벤트 테스트
+
+    @Test func capturePhoto_호출시_captureCommand_이벤트가_발생한다() async {
+        // GIVEN
+        let (browser, collector) = makeSUT()
+        await collector.startCollecting(streamType: .cameraStream)
+
+        // WHEN
+        browser.capturePhoto()
+
+        // THEN
+        let events = await collector.collectCameraStreamEvents(count: 1, timeout: 0.5)
+        #expect(events.count == 1)
+        guard case .captureCommand = events.first else {
+            Issue.record("Expected .captureCommand event, got: \(String(describing: events.first))")
+            return
+        }
+    }
+
+    // MARK: - 3. 명령 수신 테스트 (executeCommand)
+
+    @Test func capturePhoto_명령을_수신하면_captureCommand_이벤트가_발생한다() async {
+        // GIVEN
+        let (browser, collector) = makeSUT()
+        await collector.startCollecting(streamType: .cameraStream)
+
+        // 명령 데이터 생성
+        let commandData = Advertiser.CameraDeviceCommand.capturePhoto.rawValue.data(using: .utf8)!
+
+        // 더미 세션 생성 (내부 mirroringCommandSession 또는 remoteSession 시뮬레이션 필요)
+        // Note: Browser의 executeCommand는 private이므로, didReceive를 통해 호출해야 함
+        // 하지만 session이 nil이면 처리되지 않음. 이 부분은 통합 테스트 또는 리팩터링 후 테스트 가능
+
+        // WHEN - 직접 capturePhoto 호출로 대체 (명령 수신 시 내부적으로 capturePhoto가 호출됨)
+        // 리팩터링 후에는 BrowserCommandManager를 통해 테스트 가능
+        await MainActor.run {
+            browser.capturePhoto()
+        }
+
+        // THEN
+        let events = await collector.collectCameraStreamEvents(count: 1, timeout: 0.5)
+        #expect(events.count >= 1)
+        #expect(events.contains { event in
+            if case .captureCommand = event { return true }
+            return false
+        })
+    }
+
+    @Test func startTransfer_명령을_수신하면_startTransfer_이벤트가_발생한다() async {
+        // GIVEN
+        let (browser, collector) = makeSUT()
+        await collector.startCollecting(streamType: .cameraStream)
+
+        // Note: executeCommand는 private이므로 직접 테스트 불가
+        // 리팩터링 후 BrowserCommandManager를 통해 public하게 테스트 가능
+        // 현재는 통합 시나리오로 검증
+
+        // 임시: cameraStreamEventContinuation에 직접 접근 불가하므로 스킵
+        // 리팩터링 시 yield 메서드를 통해 접근 가능하게 변경 필요
+
+        // THEN - 이 테스트는 리팩터링 후 활성화
+        #expect(true, "리팩터링 후 BrowserCommandManager를 통해 테스트")
+    }
 }
 
-// MARK: - Helper
+// MARK: - Event Collector (Test Helper)
 
-/// 비동기 이벤트 대기 헬퍼
-actor Expectation<T> {
-    private var _value: T?
-    private var continuation: CheckedContinuation<T, Never>?
+/// 비동기 이벤트 스트림을 수집하는 테스트 헬퍼
+/// Mocking/Stubbing 대신 실제 스트림을 소비하고 이벤트를 배열로 수집
+actor EventCollector {
+    enum StreamType {
+        case browsing
+        case cameraStream
+    }
 
-    var value: T {
-        get async {
-            if let existing = _value {
-                return existing
+    private let browser: Browser
+    private var browsingEvents: [BrowsingEvents] = []
+    private var cameraStreamEvents: [CameraStreamEvents] = []
+    private var browsingTask: Task<Void, Never>?
+    private var cameraStreamTask: Task<Void, Never>?
+
+    init(browser: Browser) {
+        self.browser = browser
+    }
+
+    deinit {
+        browsingTask?.cancel()
+        cameraStreamTask?.cancel()
+    }
+
+    /// 이벤트 수집 시작
+    func startCollecting(streamType: StreamType, skipFirst: Int = 0) {
+        switch streamType {
+        case .browsing:
+            browsingTask = Task { [weak self] in
+                guard let self else { return }
+                var skipped = 0
+                for await event in browser.browsingEventStream {
+                    if skipped < skipFirst {
+                        skipped += 1
+                        continue
+                    }
+                    await self.appendBrowsingEvent(event)
+                }
             }
-            return await withCheckedContinuation { cont in
-                continuation = cont
+        case .cameraStream:
+            cameraStreamTask = Task { [weak self] in
+                guard let self else { return }
+                for await event in browser.cameraStreamEventStream {
+                    await self.appendCameraStreamEvent(event)
+                }
             }
         }
     }
 
-    func fulfill(with value: T) {
-        _value = value
-        continuation?.resume(returning: value)
-        continuation = nil
+    private func appendBrowsingEvent(_ event: BrowsingEvents) {
+        browsingEvents.append(event)
+    }
+
+    private func appendCameraStreamEvent(_ event: CameraStreamEvents) {
+        cameraStreamEvents.append(event)
+    }
+
+    /// Browsing 이벤트 수집 (타임아웃 지원)
+    func collectBrowsingEvents(count: Int, timeout: TimeInterval) async -> [BrowsingEvents] {
+        let deadline = Date().addingTimeInterval(timeout)
+        while browsingEvents.count < count && Date() < deadline {
+            try? await Task.sleep(nanoseconds: 10_000_000) // 10ms
+        }
+        return browsingEvents
+    }
+
+    /// CameraStream 이벤트 수집 (타임아웃 지원)
+    func collectCameraStreamEvents(count: Int, timeout: TimeInterval) async -> [CameraStreamEvents] {
+        let deadline = Date().addingTimeInterval(timeout)
+        while cameraStreamEvents.count < count && Date() < deadline {
+            try? await Task.sleep(nanoseconds: 10_000_000) // 10ms
+        }
+        return cameraStreamEvents
+    }
+
+    /// 수집된 이벤트 초기화
+    func reset() {
+        browsingEvents.removeAll()
+        cameraStreamEvents.removeAll()
     }
 }

--- a/mirroringBooth/mirroringBoothTests/BrowserTests.swift
+++ b/mirroringBooth/mirroringBoothTests/BrowserTests.swift
@@ -1,0 +1,123 @@
+//
+//  BrowserTests.swift
+//  mirroringBoothTests
+//
+//  Created by 윤대현 on 2026-02-03.
+//
+
+import Testing
+import MultipeerConnectivity
+@testable import mirroringBooth
+
+// MARK: - Browser Tests
+
+struct BrowserTests {
+
+    // MARK: - 기기 검색 (Discovery) 테스트
+
+    @Test func 주변_기기를_발견하면_deviceFound_이벤트가_발생한다() async {
+        // GIVEN
+        let browser = Browser()
+        let testPeerID = MCPeerID(displayName: "TestPeer")
+        let discoveryInfo = ["deviceType": "iPad"]
+
+        // Event 수신 Task 준비
+        let expectation = Expectation<BrowsingEvents?>()
+        let eventTask = Task {
+            for await event in browser.browsingEventStream {
+                expectation.fulfill(with: event)
+                break
+            }
+        }
+        defer { eventTask.cancel() }
+
+        // 구독 준비 시간
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        // WHEN
+        browser.browser(
+            MCNearbyServiceBrowser(peer: testPeerID, serviceType: "mirroringbooth"),
+            foundPeer: testPeerID,
+            withDiscoveryInfo: discoveryInfo
+        )
+
+        // THEN
+        let result = await expectation.value
+        guard case .deviceFound(let device) = result else {
+            Issue.record("Expected .deviceFound event")
+            return
+        }
+        #expect(device.id == "TestPeer")
+        #expect(device.type == .iPad)
+    }
+
+    @Test func 주변_기기가_사라지면_deviceLost_이벤트가_발생한다() async {
+        // GIVEN
+        let browser = Browser()
+        let testPeerID = MCPeerID(displayName: "TestPeer")
+        let discoveryInfo = ["deviceType": "iPad"]
+
+        // 먼저 기기 발견
+        browser.browser(
+            MCNearbyServiceBrowser(peer: testPeerID, serviceType: "mirroringbooth"),
+            foundPeer: testPeerID,
+            withDiscoveryInfo: discoveryInfo
+        )
+
+        // 스트림 clean up
+        _ = Task {
+            for await _ in browser.browsingEventStream { break }
+        }
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        // Event 수신 Task 준비
+        let expectation = Expectation<BrowsingEvents?>()
+        let eventTask = Task {
+            for await event in browser.browsingEventStream {
+                expectation.fulfill(with: event)
+                break
+            }
+        }
+        defer { eventTask.cancel() }
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        // WHEN
+        browser.browser(
+            MCNearbyServiceBrowser(peer: testPeerID, serviceType: "mirroringbooth"),
+            lostPeer: testPeerID
+        )
+
+        // THEN
+        let result = await expectation.value
+        guard case .deviceLost(let device) = result else {
+            Issue.record("Expected .deviceLost event")
+            return
+        }
+        #expect(device.id == "TestPeer")
+    }
+}
+
+// MARK: - Helper
+
+/// 비동기 이벤트 대기 헬퍼
+actor Expectation<T> {
+    private var _value: T?
+    private var continuation: CheckedContinuation<T, Never>?
+
+    var value: T {
+        get async {
+            if let existing = _value {
+                return existing
+            }
+            return await withCheckedContinuation { cont in
+                continuation = cont
+            }
+        }
+    }
+
+    func fulfill(with value: T) {
+        _value = value
+        continuation?.resume(returning: value)
+        continuation = nil
+    }
+}

--- a/mirroringBooth/mirroringBoothTests/BrowserTests.swift
+++ b/mirroringBooth/mirroringBoothTests/BrowserTests.swift
@@ -170,6 +170,69 @@ struct BrowserTests {
         // THEN - 이 테스트는 리팩터링 후 활성화
         #expect(true, "리팩터링 후 BrowserCommandManager를 통해 테스트")
     }
+
+    // MARK: - 4. 명령 전송 (세션 없을 때 안전성)
+
+    @Test func 세션이_없을때_sendCommand는_실패해도_크래시하지_않는다() async {
+        // GIVEN
+        let browser = Browser()
+
+        // WHEN - mirroringCommandSession이 nil인 상태
+        browser.sendCommand(.heartBeat)
+
+        // THEN - 크래시하지 않으면 성공
+        #expect(true)
+    }
+
+    @Test func 세션이_없을때_sendRemoteCommand는_실패해도_크래시하지_않는다() async {
+        // GIVEN
+        let browser = Browser()
+
+        // WHEN - remoteSession이 nil인 상태
+        browser.sendRemoteCommand(.heartBeat)
+
+        // THEN - 크래시하지 않으면 성공
+        #expect(true)
+    }
+
+    @Test func 세션이_없을때_sendStreamData는_실패해도_크래시하지_않는다() async {
+        // GIVEN
+        let browser = Browser()
+        let testData = Data([0x01, 0x02, 0x03])
+
+        // WHEN - mirroringSession이 nil인 상태
+        browser.sendStreamData(testData)
+
+        // THEN - 크래시하지 않으면 성공
+        #expect(true)
+    }
+
+    // MARK: - 5. 검색 시작/중지 및 연결 해제
+
+    @Test func startSearching_호출시_크래시하지_않는다() async {
+        // GIVEN
+        let browser = Browser()
+
+        // WHEN
+        browser.startSearching()
+
+        // THEN
+        #expect(true)
+
+        // Cleanup
+        browser.stopSearching()
+    }
+
+    @Test func disconnect_호출시_크래시하지_않는다() async {
+        // GIVEN
+        let browser = Browser()
+
+        // WHEN
+        browser.disconnect()
+
+        // THEN
+        #expect(true)
+    }
 }
 
 // MARK: - Event Collector (Test Helper)

--- a/mirroringBooth/mirroringBoothTests/BrowserTests.swift
+++ b/mirroringBooth/mirroringBoothTests/BrowserTests.swift
@@ -23,7 +23,7 @@ struct BrowserTests {
         return (browser, collector)
     }
 
-    // MARK: - 1. 기기 검색 (Discovery) 이벤트 테스트
+    // MARK: - 기기 검색
 
     @Test func 주변_기기를_발견하면_deviceFound_이벤트가_발생한다() async {
         // GIVEN
@@ -100,10 +100,10 @@ struct BrowserTests {
 
         // THEN
         let events = await collector.collectBrowsingEvents(count: 1, timeout: 0.3)
-        #expect(events.isEmpty, "deviceType 없이 발견된 기기는 이벤트가 발생하지 않아야 함")
+        #expect(events.isEmpty, "deviceType 없이 발견된 기기는 이벤트가 발생하지 않아야 합니다.")
     }
 
-    // MARK: - 2. 카메라 스트림 이벤트 테스트
+    // MARK: - 카메라 스트림 이벤트 테스트
 
     @Test func capturePhoto_호출시_captureCommand_이벤트가_발생한다() async {
         // GIVEN
@@ -122,16 +122,7 @@ struct BrowserTests {
         }
     }
 
-    // executeCommand는 현재 private이므로 리팩터링 후
-    // BrowserCommandManager를 통해 명령 수신 테스트 진행 예정입니다.
-
-    // MCSession 의존성 주입이 필요하므로 리팩터링 후
-    // 연결 상태 변경(deviceConnected, deviceConnectionFailed) 테스트 진행 예정입니다.
-
-    // sendPhotoResource 완료 이벤트(.sendPhoto)는
-    // 실제 MCSession.sendResource 콜백이 필요하므로 리팩터링 후 테스트 진행 예정
-
-    // MARK: - 4. 명령 전송 (세션 없을 때 안전성)
+    // MARK: - 명령 전송
 
     @Test func 세션이_없을때_sendCommand는_실패해도_크래시하지_않는다() async {
         // GIVEN
@@ -167,7 +158,7 @@ struct BrowserTests {
         #expect(true)
     }
 
-    // MARK: - 5. 검색 시작/중지 및 연결 해제
+    // MARK: - 검색 시작/중지 및 연결 해제
 
     @Test func startSearching_호출시_크래시하지_않는다() async {
         // GIVEN
@@ -193,12 +184,23 @@ struct BrowserTests {
         // THEN
         #expect(true)
     }
+
+    // MARK: - TODO
+
+    // executeCommand는 현재 private이므로 리팩터링 후
+    // BrowserCommandManager를 통해 명령 수신 테스트 진행 예정입니다.
+
+    // MCSession 의존성 주입이 필요하므로 리팩터링 후
+    // 연결 상태 변경(deviceConnected, deviceConnectionFailed) 테스트 진행 예정입니다.
+
+    // sendPhotoResource 완료 이벤트(.sendPhoto)는
+    // 실제 MCSession.sendResource 콜백이 필요하므로 리팩터링 후 테스트 진행 예정입니다.
 }
 
 // MARK: - Event Collector (Test Helper)
 
 /// 비동기 이벤트 스트림을 수집하는 테스트 헬퍼
-/// Mocking/Stubbing 대신 실제 스트림을 소비하고 이벤트를 배열로 수집
+/// 실제 스트림을 소비하고 이벤트를 배열로 수집합니다.
 actor EventCollector {
     enum StreamType {
         case browsing
@@ -262,7 +264,7 @@ actor EventCollector {
     func collectBrowsingEvents(count: Int, timeout: TimeInterval) async -> [BrowsingEvents] {
         let deadline = Date().addingTimeInterval(timeout)
         while browsingEvents.count < count && Date() < deadline {
-            try? await Task.sleep(nanoseconds: 10_000_000) // 10ms
+            try? await Task.sleep(nanoseconds: 10_000_000)
         }
         return browsingEvents
     }
@@ -271,7 +273,7 @@ actor EventCollector {
     func collectCameraStreamEvents(count: Int, timeout: TimeInterval) async -> [CameraStreamEvents] {
         let deadline = Date().addingTimeInterval(timeout)
         while cameraStreamEvents.count < count && Date() < deadline {
-            try? await Task.sleep(nanoseconds: 10_000_000) // 10ms
+            try? await Task.sleep(nanoseconds: 10_000_000)
         }
         return cameraStreamEvents
     }


### PR DESCRIPTION
## 🔗 연관된 이슈
- closed #288 

## 📝 작업 내용

### 📌 요약
Browser 리팩터링 전에 안전망으로 테스트 코드를 선행 작성했습니다. 

### 🔍 상세
**Browser Test Suite 내부엔 9개의 테스트 시나리오가 존재합니다.** (Swift Testing 사용했습니다.)
   - 기기 검색: 발견/사라짐/잘못된 입력 처리
   - 카메라 스트림: capturePhoto 호출 시 이벤트 발생 확인
   - 명령 전송: nil 세션일 때 크래시 안 나는지 검증
   - 기타: startSearching, disconnect 동작 확인

<img width="970" height="470" alt="image" src="https://github.com/user-attachments/assets/8d63facc-4f20-4553-9631-1f124955c649" />

또한 추가적으로 AsyncStream 이벤트를 배열로 모아서 검증할 수 있도록 헬퍼를 추가하여 활용했습니다.

## 💬 리뷰 노트
Browser 분리 후에 추가할 테스트들은 TODO 주석으로 남겨뒀습니다.