### PR TITLE
[#277] 모든 Store가 통일된 스타일을 유지하도록 수정한다.

### DIFF
--- a/mirroringBooth/StoreTests/AdvertisingStoreTests.swift
+++ b/mirroringBooth/StoreTests/AdvertisingStoreTests.swift
@@ -23,7 +23,7 @@ struct AdvertisingStoreTests {
     @Test func 화면에_진입하면_네비게이션_상태가_초기화됨() {
         let store = makeSUT()
         
-        store.send(.onAppear)
+        store.send(.entry)
         
         #expect(store.state.onNavigate == false)
         #expect(store.state.deviceUseType == nil)

--- a/mirroringBooth/StoreTests/ResultStoreTests.swift
+++ b/mirroringBooth/StoreTests/ResultStoreTests.swift
@@ -82,7 +82,7 @@ struct ResultStoreTests {
         let store = makeSUT()
         let image = UIImage()
 
-        store.send(.setRenderedImage(image: image))
+        store.send(.renderedImage(image: image))
 
         #expect(store.state.renderedImage != nil)
     }

--- a/mirroringBooth/StoreTests/StreamingStoreTests.swift
+++ b/mirroringBooth/StoreTests/StreamingStoreTests.swift
@@ -16,12 +16,12 @@ struct StreamingStoreTests {
     // MARK: - Helper
 
     private func makeSUT(
-        initialPhase: StreamingStore.OverlayPhase = .none
+        isTimerMode: Bool = false
     ) -> StreamingStore {
         StreamingStore(
             nil,
             decoder: H264Decoder(),
-            initialPhase: initialPhase
+            isTimerMode: isTimerMode
         )
     }
 
@@ -108,7 +108,7 @@ struct StreamingStoreTests {
     // MARK: - 카운트다운 시작 (startCountdown)
 
     @Test func 준비완료_버튼을_누르면_가이드_오버레이가_제거됨() {
-        let store = makeSUT(initialPhase: .guide)
+        let store = makeSUT(isTimerMode: true)
 
         store.send(.startCountdown)
 
@@ -116,7 +116,7 @@ struct StreamingStoreTests {
     }
 
     @Test func 준비완료_버튼을_누르면_카운트다운_오버레이가_추가됨() {
-        let store = makeSUT(initialPhase: .guide)
+        let store = makeSUT(isTimerMode: true)
 
         store.send(.startCountdown)
 
@@ -124,7 +124,7 @@ struct StreamingStoreTests {
     }
 
     @Test func 준비완료_버튼을_누르면_카운트다운이_8로_설정됨() {
-        let store = makeSUT(initialPhase: .guide)
+        let store = makeSUT(isTimerMode: true)
 
         store.send(.startCountdown)
 
@@ -134,7 +134,7 @@ struct StreamingStoreTests {
     // MARK: - 카운트다운 틱 (tick)
 
     @Test func 카운트다운_중_틱이_오면_값이_1_감소함() {
-        let store = makeSUT(initialPhase: .guide)
+        let store = makeSUT(isTimerMode: true)
         store.send(.startCountdown) // countdown = 8
 
         store.send(.tick) // countdown = 7
@@ -143,7 +143,7 @@ struct StreamingStoreTests {
     }
 
     @Test func 카운트다운이_1일때_틱이_오면_촬영_모드로_전환됨() {
-        let store = makeSUT(initialPhase: .guide)
+        let store = makeSUT(isTimerMode: true)
         store.send(.startCountdown)
         // 카운트다운을 1까지 내림
         for _ in 0..<7 { store.send(.tick) }
@@ -157,7 +157,7 @@ struct StreamingStoreTests {
     }
 
     @Test func 촬영_모드에서_틱이_오면_촬영간격_카운트다운이_감소함() {
-        let store = makeSUT(initialPhase: .guide)
+        let store = makeSUT(isTimerMode: true)
         store.send(.startCountdown)
         for _ in 0..<8 { store.send(.tick) } // 촬영 모드 진입, shootingCountdown = 7
 
@@ -167,7 +167,7 @@ struct StreamingStoreTests {
     }
 
     @Test func 촬영간격_카운트다운이_0이면_촬영후_7로_리셋됨() {
-        let store = makeSUT(initialPhase: .guide)
+        let store = makeSUT(isTimerMode: true)
         store.send(.startCountdown)
         for _ in 0..<8 { store.send(.tick) } // 촬영 모드 진입
         for _ in 0..<7 { store.send(.tick) } // shootingCountdown → 0
@@ -309,7 +309,7 @@ struct StreamingStoreTests {
     }
 
     @Test func 오버레이_페이즈가_변경되면_기존_페이즈가_교체됨() {
-        let store = makeSUT(initialPhase: .guide)
+        let store = makeSUT(isTimerMode: true)
 
         store.reduce(.phaseChanged(.countdown))
 
@@ -317,7 +317,7 @@ struct StreamingStoreTests {
     }
 
     @Test func 오버레이_페이즈가_추가되면_기존_페이즈에_더해짐() {
-        let store = makeSUT(initialPhase: .guide)
+        let store = makeSUT(isTimerMode: true)
 
         store.reduce(.phaseAppended(.poseSuggestion))
 
@@ -325,7 +325,7 @@ struct StreamingStoreTests {
     }
 
     @Test func 오버레이_페이즈가_제거되면_해당_페이즈만_사라짐() {
-        let store = makeSUT(initialPhase: .guide)
+        let store = makeSUT(isTimerMode: true)
         store.reduce(.phaseAppended(.poseSuggestion))
 
         store.reduce(.phaseRemoved(.guide))

--- a/mirroringBooth/StoreTests/StreamingStoreTests.swift
+++ b/mirroringBooth/StoreTests/StreamingStoreTests.swift
@@ -259,7 +259,7 @@ struct StreamingStoreTests {
     @Test func 캡쳐_효과가_켜짐() {
         let store = makeSUT()
 
-        store.send(.setShowCaptureEffect(true))
+        store.send(.showCaptureEffect(true))
 
         #expect(store.state.showCapturEffect == true)
     }
@@ -268,7 +268,7 @@ struct StreamingStoreTests {
         let store = makeSUT()
         for _ in 0..<10 { store.send(.capturePhotoCount) }
 
-        store.send(.setShowCaptureEffect(true))
+        store.send(.showCaptureEffect(true))
 
         #expect(store.state.showCapturEffect == false)
     }
@@ -278,7 +278,7 @@ struct StreamingStoreTests {
     @Test func 연결끊기_버튼을_누르면_홈_알림이_표시됨() {
         let store = makeSUT()
 
-        store.send(.setHomeAlert(true))
+        store.send(.showHomeAlert(true))
 
         #expect(store.state.showHomeAlert == true)
     }
@@ -289,7 +289,7 @@ struct StreamingStoreTests {
         let store = makeSUT()
         let size = CGSize(width: 300, height: 400)
 
-        store.send(.setVideoViewSize(size))
+        store.send(.adaptVideoViewSize(size))
 
         #expect(store.state.videoViewSize == size)
     }

--- a/mirroringBooth/StoreTests/StreamingStoreTests.swift
+++ b/mirroringBooth/StoreTests/StreamingStoreTests.swift
@@ -16,19 +16,15 @@ struct StreamingStoreTests {
     // MARK: - Helper
 
     private func makeSUT(
-        isTimerMode: Bool = false
+        isTimerMode: Bool = false,
+        isPoseMode: Bool = false
     ) -> StreamingStore {
         StreamingStore(
             nil,
             decoder: H264Decoder(),
-            isTimerMode: isTimerMode
+            isTimerMode: isTimerMode,
+            isPoseMode: isPoseMode
         )
-    }
-
-    private func makePoseList(count: Int = 3) -> [Pose] {
-        (0..<count).map { i in
-            Pose(emoji: "🧍", description: "포즈\(i)", summary: "요약\(i)")
-        }
     }
 
     // MARK: - 화면 진입 (entry)
@@ -36,7 +32,7 @@ struct StreamingStoreTests {
     @Test func 진입하면_스트리밍이_시작됨() {
         let store = makeSUT()
 
-        store.send(.entry(with: []))
+        store.send(.entry)
 
         #expect(store.state.isStreaming == true)
     }
@@ -44,42 +40,39 @@ struct StreamingStoreTests {
     @Test func 진입하면_다크모드로_설정됨() {
         let store = makeSUT()
 
-        store.send(.entry(with: []))
+        store.send(.entry)
 
         #expect(store.state.colorScheme == .dark)
     }
 
-    @Test func 포즈_리스트와_함께_진입하면_포즈_제안_오버레이가_추가됨() {
-        let store = makeSUT()
-        let poses = makePoseList()
+    @Test func 포즈모드일_경우_포즈_제안_오버레이가_추가됨() {
+        let store = makeSUT(isPoseMode: true)
 
-        store.send(.entry(with: poses))
+        store.send(.entry)
 
         #expect(store.state.overlayPhase.contains(.poseSuggestion))
     }
 
-    @Test func 포즈_리스트와_함께_진입하면_포즈가_저장됨() {
-        let store = makeSUT()
-        let poses = makePoseList(count: 5)
+    @Test func 포즈모드일_경우_포즈가_저장됨() {
+        let store = makeSUT(isPoseMode: true)
 
-        store.send(.entry(with: poses))
+        store.send(.entry)
 
-        #expect(store.state.poseList.count == 5)
+        #expect(store.state.poseList.count == 10)
     }
 
-    @Test func 빈_포즈_리스트로_진입하면_포즈_제안_오버레이가_없음() {
+    @Test func 포즈모드가_아닐_경우_포즈_제안_오버레이가_없음() {
         let store = makeSUT()
 
-        store.send(.entry(with: []))
+        store.send(.entry)
 
         #expect(!store.state.overlayPhase.contains(.poseSuggestion))
     }
 
     @Test func 현재_제안_포즈는_최대_2개까지_표시됨() {
-        let store = makeSUT()
-        let poses = makePoseList(count: 5)
+        let store = makeSUT(isPoseMode: true)
 
-        store.send(.entry(with: poses))
+        store.send(.entry)
 
         #expect(store.state.currentSuggestedPoses.count == 2)
     }
@@ -88,7 +81,7 @@ struct StreamingStoreTests {
 
     @Test func 퇴장하면_스트리밍이_중지됨() {
         let store = makeSUT()
-        store.send(.entry(with: []))
+        store.send(.entry)
 
         store.send(.exit)
 
@@ -97,7 +90,7 @@ struct StreamingStoreTests {
 
     @Test func 퇴장하면_설정이_초기화됨() {
         let store = makeSUT()
-        store.send(.entry(with: []))
+        store.send(.entry)
 
         store.send(.exit)
 
@@ -236,18 +229,17 @@ struct StreamingStoreTests {
     }
 
     @Test func 촬영_카운트_수신_시_포즈가_하나_제거됨() {
-        let store = makeSUT()
-        let poses = makePoseList(count: 3)
-        store.send(.entry(with: poses))
+        let store = makeSUT(isPoseMode: true)
+        store.send(.entry)
 
         store.send(.capturePhotoCount)
 
-        #expect(store.state.poseList.count == 2)
+        #expect(store.state.poseList.count == 9)
     }
 
     @Test func 포즈가_비어있을때_촬영_카운트_수신해도_크래시_안함() {
         let store = makeSUT()
-        store.send(.entry(with: []))
+        store.send(.entry)
 
         store.send(.capturePhotoCount)
 

--- a/mirroringBooth/WatchStoreTests/WatchStoreTests.swift
+++ b/mirroringBooth/WatchStoreTests/WatchStoreTests.swift
@@ -96,6 +96,16 @@ struct WatchStoreTests {
         #expect(store.state.connectionState == .notConnected)
     }
 
+    // MARK: - 대기 애니메이션 (setIsWaiting)
+
+    @Test func 대기_화면이_나타나면_대기_상태가_켜짐() {
+        let store = makeSUT()
+
+        store.send(.isWaitingChanged(true))
+
+        #expect(store.state.isWaiting == true)
+    }
+
     // MARK: - View 흐름 시나리오
 
     @Test func 연결부터_촬영_준비까지_전체_흐름() {

--- a/mirroringBooth/mirroringBooth/App/RootStore.swift
+++ b/mirroringBooth/mirroringBooth/App/RootStore.swift
@@ -23,6 +23,8 @@ final class RootStore: StoreProtocol {
     }
 
     private(set) var state: State = .init()
+    private var commandTask: Task<Void, Never>?
+
     var advertiser: Advertiser? {
         didSet {
             commandTask?.cancel()
@@ -30,7 +32,6 @@ final class RootStore: StoreProtocol {
         }
     }
     var browser: Browser?
-    private var commandTask: Task<Void, Never>?
 
     deinit {
         commandTask?.cancel()

--- a/mirroringBooth/mirroringBooth/App/RootStore.swift
+++ b/mirroringBooth/mirroringBooth/App/RootStore.swift
@@ -19,7 +19,7 @@ final class RootStore: StoreProtocol {
     }
 
     enum Result {
-        case showTimeoutAlert(Bool)
+        case setShowTimeoutAlert(Bool)
     }
 
     private(set) var state: State = .init()
@@ -40,7 +40,7 @@ final class RootStore: StoreProtocol {
     func action(_ intent: Intent) -> [Result] {
         switch intent {
         case .showTimeoutAlert(let bool):
-            return [.showTimeoutAlert(bool)]
+            return [.setShowTimeoutAlert(bool)]
 
         case .disconnect:
             advertiser?.disconnect()
@@ -56,7 +56,7 @@ final class RootStore: StoreProtocol {
         var state = self.state
 
         switch result {
-        case .showTimeoutAlert(let bool):
+        case .setShowTimeoutAlert(let bool):
             state.showTimeoutAlert = bool
         }
 

--- a/mirroringBooth/mirroringBooth/App/RootStore.swift
+++ b/mirroringBooth/mirroringBooth/App/RootStore.swift
@@ -40,13 +40,15 @@ final class RootStore: StoreProtocol {
         switch intent {
         case let .showTimeoutAlert(bool):
             return [.showTimeoutAlert(bool)]
+
         case .disconnect:
             advertiser?.disconnect()
             browser?.disconnect()
             advertiser = nil
             browser = nil
-            return []
         }
+
+        return []
     }
 
     func reduce(_ result: Result) {

--- a/mirroringBooth/mirroringBooth/App/RootStore.swift
+++ b/mirroringBooth/mirroringBooth/App/RootStore.swift
@@ -53,10 +53,14 @@ final class RootStore: StoreProtocol {
     }
 
     func reduce(_ result: Result) {
+        var state = self.state
+
         switch result {
         case .showTimeoutAlert(let bool):
             state.showTimeoutAlert = bool
         }
+
+        self.state = state
     }
 }
 

--- a/mirroringBooth/mirroringBooth/App/RootStore.swift
+++ b/mirroringBooth/mirroringBooth/App/RootStore.swift
@@ -38,7 +38,7 @@ final class RootStore: StoreProtocol {
 
     func action(_ intent: Intent) -> [Result] {
         switch intent {
-        case let .showTimeoutAlert(bool):
+        case .showTimeoutAlert(let bool):
             return [.showTimeoutAlert(bool)]
 
         case .disconnect:
@@ -53,7 +53,7 @@ final class RootStore: StoreProtocol {
 
     func reduce(_ result: Result) {
         switch result {
-        case let .showTimeoutAlert(bool):
+        case .showTimeoutAlert(let bool):
             state.showTimeoutAlert = bool
         }
     }

--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowsingEvents.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowsingEvents.swift
@@ -1,5 +1,5 @@
 //
-//  Browser.swift
+//  BrowsingEvents.swift
 //  mirroringBooth
 //
 //  Created by 윤대현 on 2026-02-02.

--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowsingStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowsingStore.swift
@@ -132,29 +132,16 @@ final class BrowsingStore: StoreProtocol {
     }
 
     func action(_ intent: Intent) -> [Result] {
-        var result: [Result] = []
-
         switch intent {
         case .entry:
             browser.startSearching()
             watchConnectionManager.start()
-            result.append(.startAnimation)
-            if !browser.isMirroringSessionActive {
-                if let mirroringDevice = state.mirroringDevice {
-                    result.append(.setMirroringDevice(nil))
-                    result.append(.removeDiscoveredDevice(mirroringDevice))
-                }
-                result.append(.setCurrentTarget(.mirroring))
-            } else if !browser.isRemoteSessionActive {
-                if let remoteDevice = state.remoteDevice {
-                    result.append(.setRemoteDevice(nil))
-                    result.append(.removeDiscoveredDevice(remoteDevice))
-                }
-                result.append(.setCurrentTarget(.remote))
-            }
+            return [.startAnimation] + clearDevices()
+
         case .exit:
             browser.stopSearching()
             watchConnectionManager.stop()
+
         case .didSelect(let device):
             // 1. 현재 타겟에 맞는 연결된 기기 확인
             let currentDevice: NearbyDevice? = switch state.currentTarget {
@@ -170,7 +157,7 @@ final class BrowsingStore: StoreProtocol {
                     watchConnectionManager.sendConnectionRequest()
                 } else {
                     browser.connect(to: device.id, as: state.currentTarget)
-                    result.append(.setIsConnecting(true))
+                    return [.setIsConnecting(true)]
                 }
             }
 
@@ -183,30 +170,26 @@ final class BrowsingStore: StoreProtocol {
                 watchConnectionManager.sendDisconnectionNotification()
             }
 
-            result.append(.setMirroringDevice(nil))
-            result.append(.setRemoteDevice(nil))
-
-            // 2. 리모트 선택 중이었다면 미러링 선택 화면으로 이동
-            if state.currentTarget == .remote {
-                result.append(.setCurrentTarget(.mirroring))
-            }
+            return [.setMirroringDevice(nil), .setRemoteDevice(nil)]
+                       + (state.currentTarget == .remote ? [.setCurrentTarget(.mirroring)] : [])
 
         case .didChangeAppState(let state):
             watchConnectionManager.pushIOSAppState(state: state)
 
         case .setShowMirroringDisconnectedAlert(let value):
-            result.append(.setShowMirroringDisconnectedAlert(value))
+            return [.setShowMirroringDisconnectedAlert(value)]
 
         case .setShowToast(let value):
-            result.append(.setShowToast(value))
+            return [.setShowToast(value)]
 
         case .setShowTutorial(let value):
-            result.append(.setShowTutorial(value))
+            return [.setShowTutorial(value)]
 
         case .browserEvent(let event):
-            result.append(contentsOf: handleBrowserEvent(event))
+            return handleBrowserEvent(event)
         }
-        return result
+
+        return []
     }
 
     private func handleBrowserEvent(_ event: BrowsingEvents) -> [Result] {
@@ -282,6 +265,24 @@ final class BrowsingStore: StoreProtocol {
 }
 
 extension BrowsingStore {
+    func clearDevices() -> [Result] {
+        var results: [Result] = []
+        if !browser.isMirroringSessionActive {
+            if let mirroringDevice = state.mirroringDevice {
+                results.append(.setMirroringDevice(nil))
+                results.append(.removeDiscoveredDevice(mirroringDevice))
+            }
+            results.append(.setCurrentTarget(.mirroring))
+        } else if !browser.isRemoteSessionActive {
+            if let remoteDevice = state.remoteDevice {
+                results.append(.setRemoteDevice(nil))
+                results.append(.removeDiscoveredDevice(remoteDevice))
+            }
+            results.append(.setCurrentTarget(.remote))
+        }
+        return results
+    }
+
     private func setupHeartbeatListener() {
         heartbeatTask = Task { [weak self] in
             guard let self else { return }

--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowsingStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowsingStore.swift
@@ -45,9 +45,9 @@ final class BrowsingStore: StoreProtocol {
         case didChangeAppState(UIApplication.State)
 
         // 기타
-        case setShowMirroringDisconnectedAlert(Bool)
-        case setShowToast(Bool)
-        case setShowTutorial(Bool)
+        case showMirroringDisconnectedAlert(Bool)
+        case showToast(Bool)
+        case showTutorial(Bool)
         case browserEvent(BrowsingEvents)
     }
 
@@ -187,13 +187,13 @@ final class BrowsingStore: StoreProtocol {
         case .didChangeAppState(let state):
             watchConnectionManager.pushIOSAppState(state: state)
 
-        case .setShowMirroringDisconnectedAlert(let value):
+        case .showMirroringDisconnectedAlert(let value):
             return [.setShowMirroringDisconnectedAlert(value)]
 
-        case .setShowToast(let value):
+        case .showToast(let value):
             return [.setShowToast(value)]
 
-        case .setShowTutorial(let value):
+        case .showTutorial(let value):
             return [.setShowTutorial(value)]
 
         case .browserEvent(let event):

--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowsingStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowsingStore.swift
@@ -196,17 +196,21 @@ final class BrowsingStore: StoreProtocol {
         switch event {
         case .deviceConnectionFailed:
             return [.setIsConnecting(false)]
+
         case .deviceFound(let device):
             return [.addDiscoveredDevice(device)]
+
         case .deviceLost(let device):
             if device == state.mirroringDevice {
                 return [.removeDiscoveredDevice(device), .setCurrentTarget(.mirroring)]
             }
             return [.removeDiscoveredDevice(device)]
+
         case .deviceConnected(let device):
             switch state.currentTarget {
             case .mirroring:
                 return [.setMirroringDevice(device), .setCurrentTarget(.remote), .setIsConnecting(false)]
+
             case .remote:
                 return [.setRemoteDevice(device), .setIsConnecting(false)]
             }
@@ -256,7 +260,7 @@ final class BrowsingStore: StoreProtocol {
         case .setShowToast(let value):
             state.showToast = value
 
-        case let .setShowTutorial(bool):
+        case .setShowTutorial(let bool):
             state.showTutorial = bool
         }
 

--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowsingStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowsingStore.swift
@@ -13,11 +13,11 @@ import UIKit
 final class BrowsingStore: StoreProtocol {
 
     struct State {
-        var currentTarget: DeviceUseType = .mirroring
         var discoveredDevices: [NearbyDevice] = []
         var mirroringDevice: NearbyDevice?
         var remoteDevice: NearbyDevice?
 
+        var currentTarget: DeviceUseType = .mirroring
         var isConnecting: Bool = false
         var hasSelectedDevice: Bool {
             switch currentTarget {
@@ -25,19 +25,26 @@ final class BrowsingStore: StoreProtocol {
             case .remote: return remoteDevice != nil
             }
         }
-        var animationTrigger = false
-        var showMirroringDisconnectedAlert = false
-        var showToast = false
-        var toastMessage = ""
-        var showTutorial = false
+        var animationTrigger: Bool = false
+        var showMirroringDisconnectedAlert: Bool = false
+        var showToast: Bool = false
+        var toastMessage: String = ""
+        var showTutorial: Bool = false
     }
 
     enum Intent {
+        // 화면 접근
         case entry
         case exit
+
+        // 기기 선택
         case didSelect(NearbyDevice)
         case cancel
+
+        // 앱 상태 변화
         case didChangeAppState(UIApplication.State)
+
+        // 기타
         case setShowMirroringDisconnectedAlert(Bool)
         case setShowToast(Bool)
         case setShowTutorial(Bool)
@@ -47,10 +54,13 @@ final class BrowsingStore: StoreProtocol {
     enum Result {
         case addDiscoveredDevice(NearbyDevice)
         case removeDiscoveredDevice(NearbyDevice)
+
         case setMirroringDevice(NearbyDevice?)
         case setRemoteDevice(NearbyDevice?)
+
         case setIsConnecting(Bool)
         case setCurrentTarget(DeviceUseType)
+
         case startAnimation
         case setShowMirroringDisconnectedAlert(Bool)
         case setShowToast(Bool)
@@ -58,10 +68,11 @@ final class BrowsingStore: StoreProtocol {
     }
 
     private(set) var state: State = .init()
-    let browser: Browser
-    let watchConnectionManager: WatchConnectionManager
     private var cancellables = Set<AnyCancellable>()
     private var heartbeatTask: Task<Void, Never>?
+
+    let browser: Browser
+    let watchConnectionManager: WatchConnectionManager
 
     var eventStream: AsyncStream<BrowsingEvents> {
         browser.browsingEventStream

--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowsingStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowsingStore.swift
@@ -57,7 +57,7 @@ final class BrowsingStore: StoreProtocol {
         case setShowTutorial(Bool)
     }
 
-    var state: State = .init()
+    private(set) var state: State = .init()
     let browser: Browser
     let watchConnectionManager: WatchConnectionManager
     private var cancellables = Set<AnyCancellable>()

--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowsingView.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowsingView.swift
@@ -145,7 +145,7 @@ struct BrowsingView: View {
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 Button {
-                    store.send(.setShowTutorial(true))
+                    store.send(.showTutorial(true))
                 } label: {
                     Image(systemName: "questionmark.circle")
                 }
@@ -153,12 +153,12 @@ struct BrowsingView: View {
         }
         .tutorialOverlay(isPresented: Binding(
             get: { store.state.showTutorial },
-            set: { store.send(.setShowTutorial($0)) }
+            set: { store.send(.showTutorial($0)) }
         ))
         .homeAlert(
             isPresented: Binding(
                 get: { store.state.showMirroringDisconnectedAlert },
-                set: { store.send(.setShowMirroringDisconnectedAlert($0)) }
+                set: { store.send(.showMirroringDisconnectedAlert($0)) }
             ),
             message: "미러링 기기 연결이 끊겼습니다. 다시 시도해 주세요.",
             confirmButtonText: "확인",
@@ -167,7 +167,7 @@ struct BrowsingView: View {
             .toast(
                 isPresented: Binding(
                     get: { store.state.showToast },
-                    set: { store.send(.setShowToast($0)) }
+                    set: { store.send(.showToast($0)) }
                 ), message: store.state.toastMessage)
     }
 

--- a/mirroringBooth/mirroringBooth/Device/Camera/ConnectionCheck/ConnectionCheckStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/ConnectionCheck/ConnectionCheckStore.swift
@@ -62,7 +62,7 @@ final class ConnectionCheckStore: StoreProtocol {
         switch intent {
         case .entry:
             setupHeartbeatListener()
-            
+
         case .onReadyToCapture:
             browser.sendCommand(
                 state.remoteDevice == nil
@@ -71,13 +71,13 @@ final class ConnectionCheckStore: StoreProtocol {
             )
             browser.sendRemoteCommand(.navigateToRemoteConnected)
             return [.setShowPreview(true), .setNavigationToCompletion(false)]
-            
+
         case .setNavigationToCompletion(let flag):
             return [.setNavigationToCompletion(flag)]
-            
+
         case .setShowRemoteDisconnectedAlert(let flag):
             return [.setShowRemoteDisconnectedAlert(flag)]
-            
+
         case .setShowPreview(let flag):
             return [.setShowPreview(flag)]
         }

--- a/mirroringBooth/mirroringBooth/Device/Camera/ConnectionCheck/ConnectionCheckStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/ConnectionCheck/ConnectionCheckStore.swift
@@ -19,25 +19,25 @@ final class ConnectionCheckStore: StoreProtocol {
 
     enum Intent {
         case entry
-        case setShowPreview(Bool)
+        case onReadyToCapture
         case setNavigationToCompletion(Bool)
         case setShowRemoteDisconnectedAlert(Bool)
-        case onReadyToCapture
+        case setShowPreview(Bool)
     }
 
     enum Result {
         case setRemoteDevice(String?)
-        case setShowPreview(Bool)
-        case setNavigationToCompletion(Bool)
         case setIsMirroringDisconnected(Bool)
+        case setNavigationToCompletion(Bool)
         case setShowRemoteDisconnectedAlert(Bool)
+        case setShowPreview(Bool)
     }
 
     private(set) var state: State = .init()
 
+    let browser: Browser
     let cameraDevice: String
     let mirroringDevice: String
-    let browser: Browser
 
     private var heartbeatTask: Task<Void, Never>?
 
@@ -62,17 +62,7 @@ final class ConnectionCheckStore: StoreProtocol {
         switch intent {
         case .entry:
             setupHeartbeatListener()
-            return []
-
-        case .setShowPreview(let flag):
-            return [.setShowPreview(flag)]
-
-        case .setNavigationToCompletion(let flag):
-            return [.setNavigationToCompletion(flag)]
-
-        case .setShowRemoteDisconnectedAlert(let flag):
-            return [.setShowRemoteDisconnectedAlert(flag)]
-
+            
         case .onReadyToCapture:
             browser.sendCommand(
                 state.remoteDevice == nil
@@ -81,7 +71,18 @@ final class ConnectionCheckStore: StoreProtocol {
             )
             browser.sendRemoteCommand(.navigateToRemoteConnected)
             return [.setShowPreview(true), .setNavigationToCompletion(false)]
+            
+        case .setNavigationToCompletion(let flag):
+            return [.setNavigationToCompletion(flag)]
+            
+        case .setShowRemoteDisconnectedAlert(let flag):
+            return [.setShowRemoteDisconnectedAlert(flag)]
+            
+        case .setShowPreview(let flag):
+            return [.setShowPreview(flag)]
         }
+
+        return []
     }
 
     func reduce(_ result: Result) {
@@ -91,17 +92,17 @@ final class ConnectionCheckStore: StoreProtocol {
         case .setRemoteDevice(let name):
             state.remoteDevice = name
 
-        case .setShowPreview(let flag):
-            state.showPreview = flag
+        case .setIsMirroringDisconnected(let flag):
+            state.isMirroringDisconnected = flag
 
         case .setNavigationToCompletion(let flag):
             state.shouldNavigateToCompletion = flag
 
-        case .setIsMirroringDisconnected(let flag):
-            state.isMirroringDisconnected = flag
-
         case .setShowRemoteDisconnectedAlert(let flag):
             state.showRemoteDisconnectedAlert = flag
+
+        case .setShowPreview(let flag):
+            state.showPreview = flag
         }
 
         self.state = state

--- a/mirroringBooth/mirroringBooth/Device/Camera/ConnectionCheck/ConnectionCheckStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/ConnectionCheck/ConnectionCheckStore.swift
@@ -20,9 +20,9 @@ final class ConnectionCheckStore: StoreProtocol {
     enum Intent {
         case entry
         case onReadyToCapture
-        case setNavigationToCompletion(Bool)
-        case setShowRemoteDisconnectedAlert(Bool)
-        case setShowPreview(Bool)
+        case navigateToCompletion(Bool)
+        case showRemoteDisconnectedAlert(Bool)
+        case showPreview(Bool)
     }
 
     enum Result {
@@ -72,13 +72,13 @@ final class ConnectionCheckStore: StoreProtocol {
             browser.sendRemoteCommand(.navigateToRemoteConnected)
             return [.setShowPreview(true), .setNavigationToCompletion(false)]
 
-        case .setNavigationToCompletion(let flag):
+        case .navigateToCompletion(let flag):
             return [.setNavigationToCompletion(flag)]
 
-        case .setShowRemoteDisconnectedAlert(let flag):
+        case .showRemoteDisconnectedAlert(let flag):
             return [.setShowRemoteDisconnectedAlert(flag)]
 
-        case .setShowPreview(let flag):
+        case .showPreview(let flag):
             return [.setShowPreview(flag)]
         }
 

--- a/mirroringBooth/mirroringBooth/Device/Camera/ConnectionCheck/ConnectionCheckView.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/ConnectionCheck/ConnectionCheckView.swift
@@ -74,12 +74,12 @@ struct ConnectionCheckView: View {
             .fullScreenCover(
                 isPresented: Binding(
                     get: { store.state.showPreview },
-                    set: { store.send(.setShowPreview($0)) }
+                    set: { store.send(.showPreview($0)) }
                 ),
                 onDismiss: {
                     if store.state.shouldNavigateToCompletion {
                         router.push(to: CameraRoute.completion)
-                        store.send(.setNavigationToCompletion(false))
+                        store.send(.navigateToCompletion(false))
                     }
                 },
                 content: {
@@ -87,7 +87,7 @@ struct ConnectionCheckView: View {
                         store.browser,
                         mirroringName: store.mirroringDevice,
                         onDismissByCaptureCompletion: {
-                            store.send(.setNavigationToCompletion(true))
+                            store.send(.navigateToCompletion(true))
                         }
                     )
                 }
@@ -104,7 +104,7 @@ struct ConnectionCheckView: View {
         .homeAlert(
             isPresented: Binding(
                 get: { store.state.showRemoteDisconnectedAlert },
-                set: { store.send(.setShowRemoteDisconnectedAlert($0)) }
+                set: { store.send(.showRemoteDisconnectedAlert($0)) }
             ),
             message: "리모트 기기 연결이 끊겼습니다.",
             confirmButtonText: "확인",

--- a/mirroringBooth/mirroringBooth/Device/Camera/Streaming/CameraPreviewStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Streaming/CameraPreviewStore.swift
@@ -102,25 +102,25 @@ final class CameraPreviewStore: StoreProtocol {
         switch result {
         case .updateAngle(let rawValue):
             state.angle = getAngleByRawValue(rawValue)
-            
+
         case .setTransferCount(let count):
             state.transfercount = count
-            
+
         case .setColorScheme(let scheme):
             state.colorScheme = scheme
-            
+
         case .startAnimation:
             state.animationFlag = true
-            
+
         case .setIsTransferring(let isTransferring):
             state.isTransferring = isTransferring
-            
+
         case .captureCompleted:
             state.isCaptureCompleted = true
-            
+
         case .resetCaptureCompleted:
             state.isCaptureCompleted = false
-            
+
         case .isMirroringDisconnected:
             state.isMirroringDisconnected = true
         }

--- a/mirroringBooth/mirroringBooth/Device/Camera/Streaming/CameraPreviewStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Streaming/CameraPreviewStore.swift
@@ -12,16 +12,17 @@ import SwiftUI
 @Observable
 final class CameraPreviewStore: StoreProtocol {
     struct State {
-        var animationFlag = false
         var buffer: CMSampleBuffer?
         var deviceName: String
-        var isTransferring = false
         var angle: Double = 0
+        var transfercount: Int = -1
+        var colorScheme: ColorScheme?
+
+        var animationFlag = false
+        var isTransferring = false
         var isCaptureCompleted = false
         var showHomeAlert: Bool = false
         var isMirroringDisconnected: Bool = false
-        var transfercount: Int = -1
-        var colorScheme: ColorScheme?
     }
 
     enum Intent {
@@ -33,19 +34,19 @@ final class CameraPreviewStore: StoreProtocol {
     }
 
     enum Result {
-        case startAnimation
         case updateAngle(Int)
+        case setTransferCount(Int)
+        case setColorScheme(ColorScheme?)
+        case startAnimation
+        case setIsTransferring(Bool)
         case captureCompleted
         case resetCaptureCompleted
         case isMirroringDisconnected
-        case setTransferCount(Int)
-        case setIsTransferring(Bool)
-        case setColorScheme(ColorScheme?)
     }
 
+    private(set) var state: State
     private let browser: Browser
     private let cameraManager: CameraManageable
-    private(set) var state: State
     private var cancellables = Set<AnyCancellable>()
     private var heartbeatTask: Task<Void, Never>?
 
@@ -97,31 +98,33 @@ final class CameraPreviewStore: StoreProtocol {
 
     func reduce(_ result: Result) {
         var state = self.state
-        switch result {
-        case .startAnimation:
-            state.animationFlag = true
 
+        switch result {
         case .updateAngle(let rawValue):
             state.angle = getAngleByRawValue(rawValue)
-
-        case .captureCompleted:
-            state.isCaptureCompleted = true
-
-        case .resetCaptureCompleted:
-            state.isCaptureCompleted = false
-
-        case .isMirroringDisconnected:
-            state.isMirroringDisconnected = true
-
+            
         case .setTransferCount(let count):
             state.transfercount = count
-
-        case .setIsTransferring(let isTransferring):
-            state.isTransferring = isTransferring
-
+            
         case .setColorScheme(let scheme):
             state.colorScheme = scheme
+            
+        case .startAnimation:
+            state.animationFlag = true
+            
+        case .setIsTransferring(let isTransferring):
+            state.isTransferring = isTransferring
+            
+        case .captureCompleted:
+            state.isCaptureCompleted = true
+            
+        case .resetCaptureCompleted:
+            state.isCaptureCompleted = false
+            
+        case .isMirroringDisconnected:
+            state.isMirroringDisconnected = true
         }
+
         self.state = state
     }
 }

--- a/mirroringBooth/mirroringBooth/Device/Camera/Streaming/CameraPreviewStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Streaming/CameraPreviewStore.swift
@@ -75,7 +75,8 @@ final class CameraPreviewStore: StoreProtocol {
         case .entry(let angle):
             setupSubscriptions()
             cameraManager.startSession()
-            cameraManager.rawData = { buffer in
+            cameraManager.rawData = { [weak self] buffer in
+                guard let self = self else { return }
                 self.state.buffer = buffer
             }
             return [.setColorScheme(.dark), .resetCaptureCompleted,

--- a/mirroringBooth/mirroringBooth/Device/Mirroring/PhotoComposition/Model/Photo.swift
+++ b/mirroringBooth/mirroringBooth/Device/Mirroring/PhotoComposition/Model/Photo.swift
@@ -11,7 +11,7 @@ import Foundation
 struct Photo: Identifiable, Hashable {
     let id: UUID
     let url: URL
-    let selectNumber: Int?
+    var selectNumber: Int?
 
     var imageData: Data? {
         return try? Data(contentsOf: url)

--- a/mirroringBooth/mirroringBooth/Device/Mirroring/PhotoComposition/PhotoCompositionStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Mirroring/PhotoComposition/PhotoCompositionStore.swift
@@ -12,11 +12,13 @@ final class PhotoCompositionStore: StoreProtocol {
     struct State {
         var photos: [Photo] = []
         var selectedPhotos: [Photo] = []
-        var currentSelectionCount: Int = 0
         var selectedLayout: LayoutAsset = .oneByOne
         var selectedFrame: FrameAsset = .black
+        var currentSelectionCount: Int {
+            photos.filter { $0.selectNumber != nil }.count
+        }
         var isCompletedButtonDisabled: Bool {
-            return currentSelectionCount < selectedLayout.capacity
+            currentSelectionCount < selectedLayout.capacity
         }
     }
 
@@ -31,7 +33,6 @@ final class PhotoCompositionStore: StoreProtocol {
         case setPhotos([Photo])
         case selectPhoto(Int)
         case deselectPhoto(Int)
-        case setSelectionCount(Int)
         case setLayout(LayoutAsset)
         case setFrame(FrameAsset)
     }
@@ -53,11 +54,9 @@ final class PhotoCompositionStore: StoreProtocol {
                 guard state.currentSelectionCount < state.selectedLayout.capacity else {
                     return []
                 }
-                return [.selectPhoto(index),
-                    .setSelectionCount(state.currentSelectionCount + 1)]
+                return [.selectPhoto(index)]
             } else {
-                return [.deselectPhoto(index),
-                    .setSelectionCount(state.currentSelectionCount - 1)]
+                return [.deselectPhoto(index)]
             }
 
         case .selectLayout(let layout):
@@ -72,7 +71,6 @@ final class PhotoCompositionStore: StoreProtocol {
                         results.append(.deselectPhoto(index))
                     }
                 }
-                results.append(.setSelectionCount(newCapacity))
             }
             results.append(.setLayout(layout))
             return results
@@ -106,9 +104,6 @@ final class PhotoCompositionStore: StoreProtocol {
 
         case .setFrame(let frame):
             state.selectedFrame = frame
-
-        case .setSelectionCount(let count):
-            state.currentSelectionCount = count
         }
 
         self.state = state

--- a/mirroringBooth/mirroringBooth/Device/Mirroring/PhotoComposition/PhotoCompositionStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Mirroring/PhotoComposition/PhotoCompositionStore.swift
@@ -72,15 +72,15 @@ final class PhotoCompositionStore: StoreProtocol {
         var state = self.state
 
         switch result {
-        case let .setPhotos(photos):
+        case .setPhotos(let photos):
             state.photos = photos
 
-        case let .selectPhoto(index):
+        case .selectPhoto(let index):
             let photo = state.photos[index]
             state.photos[index] = Photo(id: photo.id, url: photo.url, selectNumber: state.currentSelectionCount + 1)
             state.selectedPhotos.append(state.photos[index])
 
-        case let .deselectPhoto(index):
+        case .deselectPhoto(let index):
             var copyState = self.state
             guard let number = copyState.photos[index].selectNumber else { return }
             copyState.photos[index] = Photo(
@@ -130,7 +130,8 @@ final class PhotoCompositionStore: StoreProtocol {
 
         case .setFrame(let frame):
             state.selectedFrame = frame
-        case let .setSelectionCount(count):
+
+        case .setSelectionCount(let count):
             state.currentSelectionCount = count
         }
 

--- a/mirroringBooth/mirroringBooth/Device/Mirroring/PhotoComposition/PhotoCompositionStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Mirroring/PhotoComposition/PhotoCompositionStore.swift
@@ -61,7 +61,21 @@ final class PhotoCompositionStore: StoreProtocol {
             }
 
         case .selectLayout(let layout):
-            return [.setLayout(layout)]
+            let newCapacity = layout.capacity
+            let oldCapacity = state.selectedLayout.capacity
+            var results: [Result] = []
+            
+            // capacity가 줄어들고, 현재 선택된 이미지의 개수가 capacity를 초과하는 경우
+            if newCapacity < oldCapacity && state.currentSelectionCount > newCapacity {
+                for (index, photo) in state.photos.enumerated() {
+                    if let selectNumber = photo.selectNumber, selectNumber > newCapacity {
+                        results.append(.deselectPhoto(index))
+                    }
+                }
+                results.append(.setSelectionCount(newCapacity))
+            }
+            results.append(.setLayout(layout))
+            return results
 
         case .selectFrame(let frame):
             return [.setFrame(frame)]
@@ -76,57 +90,19 @@ final class PhotoCompositionStore: StoreProtocol {
             state.photos = photos
 
         case .selectPhoto(let index):
-            let photo = state.photos[index]
-            state.photos[index] = Photo(id: photo.id, url: photo.url, selectNumber: state.currentSelectionCount + 1)
+            state.photos[index].selectNumber = state.currentSelectionCount + 1
             state.selectedPhotos.append(state.photos[index])
 
         case .deselectPhoto(let index):
-            var copyState = self.state
-            guard let number = copyState.photos[index].selectNumber else { return }
-            copyState.photos[index] = Photo(
-                id: copyState.photos[index].id,
-                url: copyState.photos[index].url,
-                selectNumber: nil
-            )
-            copyState.selectedPhotos.remove(at: number - 1)
-            for (index, photo) in copyState.photos.enumerated() {
-                if let iterator = photo.selectNumber, iterator > number {
-                    copyState.photos[index] = Photo(
-                        id: photo.id,
-                        url: photo.url,
-                        selectNumber: iterator - 1
-                    )
-                }
+            guard let number = state.photos[index].selectNumber else { return }
+            state.photos[index].selectNumber = nil
+            state.selectedPhotos.remove(at: number - 1)
+            for index in state.photos.indices where state.photos[index].selectNumber ?? 0 > number {
+                state.photos[index].selectNumber? -= 1
             }
-            state = copyState
 
         case .setLayout(let layout):
-            var copyState = state
-            let newCapacity = layout.capacity
-            let oldCapacity = state.selectedLayout.capacity
-
-            // capacity가 줄어들고, 현재 선택된 이미지의 개수가 capacity를 초과하는 경우만 처리합니다.
-            if newCapacity < oldCapacity && copyState.currentSelectionCount > newCapacity {
-                // 초과된 사진 사진들의 selectNumber 제거
-                for index in 0 ..< copyState.photos.count {
-                    if let selectNumber = copyState.photos[index].selectNumber,
-                       selectNumber > newCapacity {
-                        copyState.photos[index] = Photo(
-                            id: copyState.photos[index].id,
-                            url: copyState.photos[index].url,
-                            selectNumber: nil
-                        )
-                    }
-                }
-
-                copyState.selectedPhotos = copyState.photos
-                    .filter { $0.selectNumber != nil }
-                    .sorted { ($0.selectNumber ?? 0) < ($1.selectNumber ?? 0) }
-
-                copyState.currentSelectionCount = copyState.selectedPhotos.count
-            }
-            copyState.selectedLayout = layout
-            state = copyState
+            state.selectedLayout = layout
 
         case .setFrame(let frame):
             state.selectedFrame = frame

--- a/mirroringBooth/mirroringBooth/Device/Mirroring/PhotoComposition/PhotoCompositionStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Mirroring/PhotoComposition/PhotoCompositionStore.swift
@@ -36,7 +36,7 @@ final class PhotoCompositionStore: StoreProtocol {
         case setFrame(FrameAsset)
     }
 
-    var state: State = .init()
+    private(set) var state: State = .init()
 
     func action(_ intent: Intent) -> [Result] {
         switch intent {

--- a/mirroringBooth/mirroringBooth/Device/Mirroring/PhotoComposition/PhotoCompositionStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Mirroring/PhotoComposition/PhotoCompositionStore.swift
@@ -47,21 +47,19 @@ final class PhotoCompositionStore: StoreProtocol {
                 return Photo(id: UUID(), url: url, selectNumber: nil)
             }
             return [.setPhotos(photos)]
-        case let .selectPhoto(index):
+
+        case .selectPhoto(let index):
             if state.photos[index].selectNumber == nil {
                 guard state.currentSelectionCount < state.selectedLayout.capacity else {
                     return []
                 }
-                return [
-                    .selectPhoto(index),
-                    .setSelectionCount(state.currentSelectionCount + 1)
-                ]
+                return [.selectPhoto(index),
+                    .setSelectionCount(state.currentSelectionCount + 1)]
             } else {
-                return [
-                    .deselectPhoto(index),
-                    .setSelectionCount(state.currentSelectionCount - 1)
-                ]
+                return [.deselectPhoto(index),
+                    .setSelectionCount(state.currentSelectionCount - 1)]
             }
+
         case .selectLayout(let layout):
             return [.setLayout(layout)]
 

--- a/mirroringBooth/mirroringBooth/Device/Mirroring/PhotoComposition/PhotoCompositionStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Mirroring/PhotoComposition/PhotoCompositionStore.swift
@@ -64,7 +64,7 @@ final class PhotoCompositionStore: StoreProtocol {
             let newCapacity = layout.capacity
             let oldCapacity = state.selectedLayout.capacity
             var results: [Result] = []
-            
+
             // capacity가 줄어들고, 현재 선택된 이미지의 개수가 capacity를 초과하는 경우
             if newCapacity < oldCapacity && state.currentSelectionCount > newCapacity {
                 for (index, photo) in state.photos.enumerated() {

--- a/mirroringBooth/mirroringBooth/Device/Mirroring/PhotoResult/ResultStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Mirroring/PhotoResult/ResultStore.swift
@@ -64,26 +64,26 @@ final class ResultStore: StoreProtocol {
         switch intent {
         case .setRenderedImage(let image):
             return [.setRenderedImage(image)]
-            
+
         case .setScale(let scale):
             return [.setScale(scale)]
-            
+
         case .setLastScale(let scale):
             return [.setLastScale(scale)]
-            
+
         case .showFileExporter(let bool, let document):
             return [.setShowFileExporter(bool, document: document)]
-            
+
         case .showHomeAlert(let bool):
             return [.setShowHomeAlert(bool)]
-            
+
         case .showSettingAlert(let bool):
             saveResultImage(state.renderedImage ?? UIImage())
             return [.showSettingAlert(bool)]
-            
+
         case .showSavedToast(let bool, let message):
             return [.setShowSavedToast(bool, message: message)]
-            
+
         case .showShareSheet(let bool):
             return [.setShowShareSheet(bool)]
         }

--- a/mirroringBooth/mirroringBooth/Device/Mirroring/PhotoResult/ResultStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Mirroring/PhotoResult/ResultStore.swift
@@ -91,30 +91,37 @@ final class ResultStore: StoreProtocol {
 
     @MainActor
     func reduce(_ result: Result) {
+        var state = self.state
+
         switch result {
-        case .setShowHomeAlert(let bool):
-            state.showHomeAlert = bool
-        case .setShowSavedToast(let bool, let message):
-            var newState = self.state
-            newState.toastMessage = message ?? ""
-            newState.showSavedToast = bool
-            self.state = newState
-        case .showSettingAlert(let bool):
-                    self.state.showSettingAlert = bool
-        case .setShowFileExporter(let bool, let document):
-            var newState = self.state
-            newState.document = document
-            newState.showFileExporter = bool
-            self.state = newState
         case .setRenderedImage(let image):
             state.renderedImage = image
-        case .setShowShareSheet(let bool):
-            state.showShareSheet = bool
+
         case .setScale(let scale):
             state.scale = scale
+
         case .setLastScale(let lastScale):
             state.lastScale = lastScale
+
+        case .setShowFileExporter(let bool, let document):
+            state.document = document
+            state.showFileExporter = bool
+
+        case .setShowHomeAlert(let bool):
+            state.showHomeAlert = bool
+
+        case .showSettingAlert(let bool):
+            state.showSettingAlert = bool
+
+        case .setShowSavedToast(let bool, let message):
+            state.toastMessage = message ?? ""
+            state.showSavedToast = bool
+
+        case .setShowShareSheet(let bool):
+            state.showShareSheet = bool
         }
+
+        self.state = state
     }
 
     private func saveResultImage(_ image: UIImage) {

--- a/mirroringBooth/mirroringBooth/Device/Mirroring/PhotoResult/ResultStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Mirroring/PhotoResult/ResultStore.swift
@@ -26,7 +26,7 @@ final class ResultStore: StoreProtocol {
     }
 
     enum Intent {
-        case setRenderedImage(image: UIImage)
+        case renderedImage(image: UIImage)
         case setScale(scale: CGFloat)
         case setLastScale(scale: CGFloat)
 
@@ -44,7 +44,7 @@ final class ResultStore: StoreProtocol {
 
         case setShowFileExporter(Bool, document: ImageDocument? = nil)
         case setShowHomeAlert(Bool)
-        case showSettingAlert(Bool)
+        case setShowSettingAlert(Bool)
         case setShowSavedToast(Bool, message: String? = nil)
         case setShowShareSheet(Bool)
     }
@@ -62,7 +62,7 @@ final class ResultStore: StoreProtocol {
 
     func action(_ intent: Intent) -> [Result] {
         switch intent {
-        case .setRenderedImage(let image):
+        case .renderedImage(let image):
             return [.setRenderedImage(image)]
 
         case .setScale(let scale):
@@ -79,7 +79,7 @@ final class ResultStore: StoreProtocol {
 
         case .showSettingAlert(let bool):
             saveResultImage(state.renderedImage ?? UIImage())
-            return [.showSettingAlert(bool)]
+            return [.setShowSettingAlert(bool)]
 
         case .showSavedToast(let bool, let message):
             return [.setShowSavedToast(bool, message: message)]
@@ -110,7 +110,7 @@ final class ResultStore: StoreProtocol {
         case .setShowHomeAlert(let bool):
             state.showHomeAlert = bool
 
-        case .showSettingAlert(let bool):
+        case .setShowSettingAlert(let bool):
             state.showSettingAlert = bool
 
         case .setShowSavedToast(let bool, let message):

--- a/mirroringBooth/mirroringBooth/Device/Mirroring/PhotoResult/ResultStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Mirroring/PhotoResult/ResultStore.swift
@@ -11,57 +11,41 @@ import UIKit
 @Observable
 final class ResultStore: StoreProtocol {
     struct State {
-        // Photo Information
         var resultPhoto: PhotoInformation?
-
-        // home alert
-        var showHomeAlert: Bool = false
-
-        // toast
-        var showSavedToast: Bool = false
-        var toastMessage: String = ""
-
-        // setting alert
-        var showSettingAlert: Bool = false
-
-        // fileExporter
-        var showFileExporter: Bool = false
-        var document: ImageDocument?
-
-        // result image
         var renderedImage: UIImage?
-
-        // scale
         var scale: CGFloat = 1
         var lastScale: CGFloat = 1
 
-        // share sheet
+        var showFileExporter: Bool = false
+        var document: ImageDocument?
+        var showHomeAlert: Bool = false
+        var showSettingAlert: Bool = false
+        var showSavedToast: Bool = false
+        var toastMessage: String = ""
         var showShareSheet: Bool = false
     }
 
     enum Intent {
-        case showHomeAlert(Bool)
-        case showSavedToast(Bool, message: String? = nil)
-        case showSettingAlert(Bool)
-        case showFileExporter(Bool, document: ImageDocument? = nil)
         case setRenderedImage(image: UIImage)
         case setScale(scale: CGFloat)
         case setLastScale(scale: CGFloat)
 
+        case showFileExporter(Bool, document: ImageDocument? = nil)
+        case showHomeAlert(Bool)
+        case showSettingAlert(Bool)
+        case showSavedToast(Bool, message: String? = nil)
         case showShareSheet(Bool)
     }
 
     enum Result {
-        case setShowHomeAlert(Bool)
-
-        case setShowSavedToast(Bool, message: String? = nil)
-        case showSettingAlert(Bool)
-        case setShowFileExporter(Bool, document: ImageDocument? = nil)
         case setRenderedImage(UIImage)
-
         case setScale(CGFloat)
         case setLastScale(CGFloat)
 
+        case setShowFileExporter(Bool, document: ImageDocument? = nil)
+        case setShowHomeAlert(Bool)
+        case showSettingAlert(Bool)
+        case setShowSavedToast(Bool, message: String? = nil)
         case setShowShareSheet(Bool)
     }
 
@@ -78,30 +62,30 @@ final class ResultStore: StoreProtocol {
 
     func action(_ intent: Intent) -> [Result] {
         switch intent {
+        case .setRenderedImage(let image):
+            return [.setRenderedImage(image)]
+            
+        case .setScale(let scale):
+            return [.setScale(scale)]
+            
+        case .setLastScale(let scale):
+            return [.setLastScale(scale)]
+            
+        case .showFileExporter(let bool, let document):
+            return [.setShowFileExporter(bool, document: document)]
+            
         case .showHomeAlert(let bool):
             return [.setShowHomeAlert(bool)]
-
-        case .showSavedToast(let bool, let message):
-            return [.setShowSavedToast(bool, message: message)]
-
+            
         case .showSettingAlert(let bool):
             saveResultImage(state.renderedImage ?? UIImage())
             return [.showSettingAlert(bool)]
-
-        case .showFileExporter(let bool, let document):
-            return [.setShowFileExporter(bool, document: document)]
-
+            
+        case .showSavedToast(let bool, let message):
+            return [.setShowSavedToast(bool, message: message)]
+            
         case .showShareSheet(let bool):
             return [.setShowShareSheet(bool)]
-
-        case .setRenderedImage(let image):
-            return [.setRenderedImage(image)]
-
-        case .setScale(let scale):
-            return [.setScale(scale)]
-
-        case .setLastScale(let scale):
-            return [.setLastScale(scale)]
         }
     }
 

--- a/mirroringBooth/mirroringBooth/Device/Mirroring/PhotoResult/ResultView.swift
+++ b/mirroringBooth/mirroringBooth/Device/Mirroring/PhotoResult/ResultView.swift
@@ -150,7 +150,7 @@ struct ResultView: View {
         .task {
             if let photoInformation = store.state.resultPhoto {
                 guard let image = PhotoComposer.render(with: photoInformation) else { return }
-                store.send(.setRenderedImage(image: image))
+                store.send(.renderedImage(image: image))
             }
         }
         .toast(

--- a/mirroringBooth/mirroringBooth/Device/Mirroring/Streaming/StreamingStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Mirroring/Streaming/StreamingStore.swift
@@ -17,10 +17,10 @@ final class StreamingStore: StoreProtocol {
 
         case none
         case guide // 가이드라인 오버레이
-        case countdown // 8, 7, 6, 5, 4, 3, 2, 1 카운트다운
-        case shooting // 촬영 중 (8초 간격)
+        case countdown // 촬영 시작 전 카운트다운
+        case shooting // 촬영 중 (8초 간격) 카운트다운
         case transferring // 전송, 수신 중
-        case poseSuggestion
+        case poseSuggestion // 포즈 추천
         case completed // 촬영 완료
     }
 
@@ -112,13 +112,13 @@ final class StreamingStore: StoreProtocol {
     }
 
     private(set) var state: State
-    let isTimerMode: Bool
-
     private let advertiser: Advertiser?
     private let decoder: H264Decoder
     private var timer: Timer?
     private var streamingTask: Task<Void, Never>?
     private var commandTask: Task<Void, Never>?
+
+    let isTimerMode: Bool
 
     init(
         _ advertiser: Advertiser?,

--- a/mirroringBooth/mirroringBooth/Device/Mirroring/Streaming/StreamingStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Mirroring/Streaming/StreamingStore.swift
@@ -59,7 +59,7 @@ final class StreamingStore: StoreProtocol {
 
     enum Intent {
         // 화면 접근
-        case entry(with: [Pose])
+        case entry
         case exit
 
         // 타이머 모드
@@ -119,15 +119,18 @@ final class StreamingStore: StoreProtocol {
     private var commandTask: Task<Void, Never>?
 
     let isTimerMode: Bool
+    let isPoseMode: Bool
 
     init(
         _ advertiser: Advertiser?,
         decoder: H264Decoder,
-        isTimerMode: Bool
+        isTimerMode: Bool,
+        isPoseMode: Bool
     ) {
-        self.isTimerMode = isTimerMode
         self.advertiser = advertiser
         self.decoder = decoder
+        self.isTimerMode = isTimerMode
+        self.isPoseMode = isPoseMode
         self.state = State(overlayPhase: [isTimerMode ? .guide : .none])
 
         decoder.onDecodedSampleBuffer = { [weak self] sampleBuffer, rotationAngle in
@@ -141,7 +144,8 @@ final class StreamingStore: StoreProtocol {
     func action(_ intent: Intent) -> [Result] {
         switch intent {
             // MARK: - 화면 접근
-        case .entry(let poseList):
+        case .entry:
+            let poseList: [Pose] = isPoseMode ? PoseSuggestor.suggest(count: 10) : []
             return [.setColorScheme(.dark), .streamingStarted, .setPoseList(poseList)]
                         + (!poseList.isEmpty ? [.phaseAppended(.poseSuggestion)] : [])
 

--- a/mirroringBooth/mirroringBooth/Device/Mirroring/Streaming/StreamingStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Mirroring/Streaming/StreamingStore.swift
@@ -112,6 +112,7 @@ final class StreamingStore: StoreProtocol {
     }
 
     private(set) var state: State
+    let isTimerMode: Bool
 
     private let advertiser: Advertiser?
     private let decoder: H264Decoder
@@ -122,11 +123,12 @@ final class StreamingStore: StoreProtocol {
     init(
         _ advertiser: Advertiser?,
         decoder: H264Decoder,
-        initialPhase: OverlayPhase
+        isTimerMode: Bool
     ) {
+        self.isTimerMode = isTimerMode
         self.advertiser = advertiser
         self.decoder = decoder
-        self.state = State(overlayPhase: [initialPhase])
+        self.state = State(overlayPhase: [isTimerMode ? .guide : .none])
 
         decoder.onDecodedSampleBuffer = { [weak self] sampleBuffer, rotationAngle in
             Task { @MainActor in

--- a/mirroringBooth/mirroringBooth/Device/Mirroring/Streaming/StreamingStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Mirroring/Streaming/StreamingStore.swift
@@ -139,66 +139,56 @@ final class StreamingStore: StoreProtocol {
     }
 
     func action(_ intent: Intent) -> [Result] {
-        var result: [Result] = []
-
         switch intent {
             // MARK: - 화면 접근
         case .entry(let poseList):
-            if !poseList.isEmpty {
-                result.append(.phaseAppended(.poseSuggestion))
-            }
-            result.append(.setColorScheme(.dark))
-            result.append(.streamingStarted)
-            result.append(.setPoseList(poseList))
+            return [.setColorScheme(.dark), .streamingStarted, .setPoseList(poseList)]
+                        + (!poseList.isEmpty ? [.phaseAppended(.poseSuggestion)] : [])
 
         case .exit:
             decoder.stop()
-            result.append(.setColorScheme(nil))
             streamingTask?.cancel()
-            result.append(.streamingStopped)
+            return [.setColorScheme(nil), .streamingStopped]
 
             // MARK: - 타이머
         case .startCountdown:
-            result.append(.phaseRemoved(.guide))
-            result.append(.phaseAppended(.countdown))
-            result.append(.countdownUpdated(8))
             startTimer()
+            return [.phaseRemoved(.guide), .phaseAppended(.countdown), .countdownUpdated(8)]
 
         case .tick:
-            result.append(contentsOf: handleTick())
+            return handleTick()
 
             // MARK: - 사진 전송
         case .startTransfer:
-            result.append(.phaseChanged(.transferring))
             advertiser?.sendCommand(.startTransfer)
             advertiser?.setupCacheManager()
+            return [.phaseChanged(.transferring)]
 
         case .photoReceived:
             let newCount = state.receivedPhotoCount + 1
-            result.append(.receivedPhotoCountUpdated(newCount))
             if newCount >= state.totalCaptureCount {
                 advertiser?.stopHeartBeating()
-                result.append(.phaseChanged(.completed))
+                return [.receivedPhotoCountUpdated(newCount), .phaseChanged(.completed)]
             }
+            return [.receivedPhotoCountUpdated(newCount)]
 
         case .capturePhotoCount:
             let newCount = min(state.totalCaptureCount, state.capturePhotoCount + 1)
-            result.append(.capturePhotoCountUpdated(newCount))
-            result.append(.removePose)
+            return [.capturePhotoCountUpdated(newCount), .removePose]
 
         case .setShowCaptureEffect(let value):
             if state.capturePhotoCount < state.totalCaptureCount {
-                result.append(.setShowCaptureEffect(value))
+                return [.setShowCaptureEffect(value)]
             }
 
         case .setHomeAlert(let value):
-            result.append(.setHomeAlert(value))
+            return [.setHomeAlert(value)]
 
         case .setVideoViewSize(let value):
-            result.append(.setVideoViewSize(value))
+            return [.setVideoViewSize(value)]
         }
 
-        return result
+        return []
     }
 
     func reduce(_ result: Result) {

--- a/mirroringBooth/mirroringBooth/Device/Mirroring/Streaming/StreamingStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Mirroring/Streaming/StreamingStore.swift
@@ -216,6 +216,7 @@ final class StreamingStore: StoreProtocol {
         case .videoFrameDecoded(let sampleBuffer, let rotationAngle):
             state.currentSampleBuffer = sampleBuffer
             state.rotationAngle = rotationAngle
+
             // MARK: - 타이머
         case .countdownUpdated(let value):
             state.countdownValue = value

--- a/mirroringBooth/mirroringBooth/Device/Mirroring/Streaming/StreamingStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Mirroring/Streaming/StreamingStore.swift
@@ -72,11 +72,11 @@ final class StreamingStore: StoreProtocol {
         case capturePhotoCount  // 촬영 카운트 수신
 
         // 캡쳐 효과
-        case setShowCaptureEffect(Bool)
+        case showCaptureEffect(Bool)
 
         // 그 외
-        case setHomeAlert(Bool)
-        case setVideoViewSize(CGSize)
+        case showHomeAlert(Bool)
+        case adaptVideoViewSize(CGSize)
     }
 
     enum Result {
@@ -106,7 +106,7 @@ final class StreamingStore: StoreProtocol {
         case removePose
 
         // 그 외
-        case setHomeAlert(Bool)
+        case setShowHomeAlert(Bool)
         case setVideoViewSize(CGSize)
         case setColorScheme(ColorScheme?)
     }
@@ -176,15 +176,15 @@ final class StreamingStore: StoreProtocol {
             let newCount = min(state.totalCaptureCount, state.capturePhotoCount + 1)
             return [.capturePhotoCountUpdated(newCount), .removePose]
 
-        case .setShowCaptureEffect(let value):
+        case .showCaptureEffect(let value):
             if state.capturePhotoCount < state.totalCaptureCount {
                 return [.setShowCaptureEffect(value)]
             }
 
-        case .setHomeAlert(let value):
-            return [.setHomeAlert(value)]
+        case .showHomeAlert(let value):
+            return [.setShowHomeAlert(value)]
 
-        case .setVideoViewSize(let value):
+        case .adaptVideoViewSize(let value):
             return [.setVideoViewSize(value)]
         }
 
@@ -241,7 +241,7 @@ final class StreamingStore: StoreProtocol {
                 state.poseList.removeFirst()
             }
 
-        case .setHomeAlert(let value):
+        case .setShowHomeAlert(let value):
             state.showHomeAlert = value
 
         case .setVideoViewSize(let size):
@@ -338,10 +338,10 @@ extension StreamingStore {
 extension StreamingStore {
     @MainActor
     func captureEffect() {
-        self.send(.setShowCaptureEffect(true))
+        self.send(.showCaptureEffect(true))
         Task { @MainActor [weak self] in
             try? await Task.sleep(nanoseconds: 200_000_000)
-            self?.send(.setShowCaptureEffect(false))
+            self?.send(.showCaptureEffect(false))
         }
     }
 }

--- a/mirroringBooth/mirroringBooth/Device/Mirroring/Streaming/StreamingStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Mirroring/Streaming/StreamingStore.swift
@@ -111,7 +111,7 @@ final class StreamingStore: StoreProtocol {
         case setColorScheme(ColorScheme?)
     }
 
-    var state: State
+    private(set) var state: State
 
     private let advertiser: Advertiser?
     private let decoder: H264Decoder

--- a/mirroringBooth/mirroringBooth/Device/Mirroring/Streaming/StreamingView.swift
+++ b/mirroringBooth/mirroringBooth/Device/Mirroring/Streaming/StreamingView.swift
@@ -59,9 +59,9 @@ struct StreamingView: View {
                     .background {
                         GeometryReader { geometry in
                             Color.clear
-                                .onAppear { store.send(.setVideoViewSize(geometry.size)) }
+                                .onAppear { store.send(.adaptVideoViewSize(geometry.size)) }
                                 .onChange(of: geometry.size) { _, size in
-                                    store.send(.setVideoViewSize(size) )
+                                    store.send(.adaptVideoViewSize(size) )
                                 }
                         }
                     }
@@ -119,7 +119,7 @@ struct StreamingView: View {
         .homeAlert(
             isPresented: Binding(
                 get: { store.state.showHomeAlert },
-                set: { store.send(.setHomeAlert($0)) }
+                set: { store.send(.showHomeAlert($0)) }
             ),
             message: "촬영된 사진이 모두 사라집니다.\n연결을 종료하시겠습니까?"
         ) {
@@ -163,7 +163,7 @@ struct StreamingView: View {
                             textFont: isCompact ? .caption : .callout,
                             backgroundColor: .black.opacity(0.5)
                         ) {
-                            store.send(.setHomeAlert(true))
+                            store.send(.showHomeAlert(true))
                         }
                         .padding(.horizontal, -20)
                         .padding(.vertical, -15)

--- a/mirroringBooth/mirroringBooth/Device/Mirroring/Streaming/StreamingView.swift
+++ b/mirroringBooth/mirroringBooth/Device/Mirroring/Streaming/StreamingView.swift
@@ -11,21 +11,17 @@ struct StreamingView: View {
     @Environment(Router.self) var router: Router
     @Environment(RootStore.self) private var rootStore
     @State private var store: StreamingStore
-    let advertiser: Advertiser?
-    private let isTimerMode: Bool
-    private let poseList: [Pose]
+    private let isPoseModeOn: Bool
 
     init(advertiser: Advertiser?, isTimerMode: Bool, isPoseModeOn: Bool) {
-        self.advertiser = advertiser
-        self.isTimerMode = isTimerMode
         self._store = State(
             initialValue: StreamingStore(
                 advertiser,
                 decoder: H264Decoder(),
-                initialPhase: isTimerMode ? .guide : .none
+                isTimerMode: isTimerMode
             )
         )
-        self.poseList = isPoseModeOn ? PoseSuggestor.suggest(count: 10) : []
+        self.isPoseModeOn = isPoseModeOn
     }
 
     private enum StreamingLayoutType {
@@ -109,7 +105,7 @@ struct StreamingView: View {
         .preferredColorScheme(store.state.colorScheme)
         .onAppear {
             AppDelegate.unlockOrientation()
-            store.send(.entry(with: poseList))
+            store.send(.entry(with: isPoseModeOn ? PoseSuggestor.suggest(count: 10) : []))
         }
         .onDisappear {
             AppDelegate.lockOrientation()
@@ -156,7 +152,7 @@ struct StreamingView: View {
     private var streamingHUD: some View {
         GeometryReader { geometry in
             let layoutType = StreamingLayoutType(width: geometry.size.width)
-            let isShooting = isTimerMode && store.state.overlayPhase.contains(.shooting)
+            let isShooting = store.isTimerMode && store.state.overlayPhase.contains(.shooting)
             let isCompact = layoutType == .compact
 
             ZStack {

--- a/mirroringBooth/mirroringBooth/Device/Mirroring/Streaming/StreamingView.swift
+++ b/mirroringBooth/mirroringBooth/Device/Mirroring/Streaming/StreamingView.swift
@@ -11,17 +11,16 @@ struct StreamingView: View {
     @Environment(Router.self) var router: Router
     @Environment(RootStore.self) private var rootStore
     @State private var store: StreamingStore
-    private let isPoseModeOn: Bool
 
     init(advertiser: Advertiser?, isTimerMode: Bool, isPoseModeOn: Bool) {
         self._store = State(
             initialValue: StreamingStore(
                 advertiser,
                 decoder: H264Decoder(),
-                isTimerMode: isTimerMode
+                isTimerMode: isTimerMode,
+                isPoseMode: isPoseModeOn
             )
         )
-        self.isPoseModeOn = isPoseModeOn
     }
 
     private enum StreamingLayoutType {
@@ -105,7 +104,7 @@ struct StreamingView: View {
         .preferredColorScheme(store.state.colorScheme)
         .onAppear {
             AppDelegate.unlockOrientation()
-            store.send(.entry(with: isPoseModeOn ? PoseSuggestor.suggest(count: 10) : []))
+            store.send(.entry)
         }
         .onDisappear {
             AppDelegate.lockOrientation()

--- a/mirroringBooth/mirroringBooth/Device/Remote/AppleWatch/View/WatchConnectionView.swift
+++ b/mirroringBooth/mirroringBooth/Device/Remote/AppleWatch/View/WatchConnectionView.swift
@@ -10,7 +10,6 @@ import SwiftUI
 struct WatchConnectionView: View {
     let onClose: () -> Void
     @State private var store = WatchConnectionStore(connectionManager: WatchConnectionManager())
-    @State private var spin = false
 
     var body: some View {
         Group {
@@ -57,16 +56,16 @@ struct WatchConnectionView: View {
                 Image(systemName: "arrow.2.circlepath")
                     .font(.title2)
                     .rotationEffect(.degrees(-45))
-                    .rotationEffect(.degrees(spin ? 360 : 0))
+                    .rotationEffect(.degrees(store.state.isWaiting ? 360 : 0))
                     .animation(
                         .linear(duration: 1).repeatForever(autoreverses: false),
-                        value: spin
+                        value: store.state.isWaiting
                     )
                     .onAppear {
-                        spin = true
+                        store.send(.isWaitingChanged(true))
                     }
                     .onDisappear {
-                        spin = false
+                        store.send(.isWaitingChanged(false))
                     }
 
                 Text("연결 대기 중...")

--- a/mirroringBooth/mirroringBooth/Device/Remote/AppleWatch/WatchConnectionStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Remote/AppleWatch/WatchConnectionStore.swift
@@ -30,8 +30,8 @@ final class WatchConnectionStore: StoreProtocol {
         case setIsWaiting(Bool)
     }
 
-    private let connectionManager: WatchConnectionManager
     private(set) var state: State = .init()
+    private let connectionManager: WatchConnectionManager
 
     init(
         connectionManager: WatchConnectionManager
@@ -74,16 +74,17 @@ final class WatchConnectionStore: StoreProtocol {
                 await self?.connectionManager.sendCaptureRequest()
             }
 
+        case .startConnecting:
+            self.connectionManager.start()
+
         case .disconnect:
             self.connectionManager.stop()
             return [.setConnectionState(.notConnected)]
 
-        case .startConnecting:
-            self.connectionManager.start()
-
         case .isWaitingChanged(let isWaiting):
             return [.setIsWaiting(isWaiting)]
         }
+
         return []
     }
 

--- a/mirroringBooth/mirroringBooth/Device/Remote/AppleWatch/WatchConnectionStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Remote/AppleWatch/WatchConnectionStore.swift
@@ -13,18 +13,21 @@ final class WatchConnectionStore: StoreProtocol {
         var connectionState: ConnectionState = .notConnected
         var isReadyToCapture: Bool = false
         var isCaptureCompleted: Bool = false
+        var isWaiting: Bool = false
     }
 
     enum Intent {
         case tapRequestCapture
         case startConnecting
         case disconnect
+        case isWaitingChanged(Bool)
     }
 
     enum Result {
         case setConnectionState(ConnectionState)
         case setIsReadyToCapture(Bool)
         case setIsCaptureCompleted(Bool)
+        case setIsWaiting(Bool)
     }
 
     private let connectionManager: WatchConnectionManager
@@ -75,6 +78,8 @@ final class WatchConnectionStore: StoreProtocol {
             return [.setConnectionState(.notConnected)]
         case .startConnecting:
             self.connectionManager.start()
+        case .isWaitingChanged(let isWaiting):
+            return [.setIsWaiting(isWaiting)]
         }
         return []
     }
@@ -89,6 +94,8 @@ final class WatchConnectionStore: StoreProtocol {
             state.isReadyToCapture = value
         case .setIsCaptureCompleted(let value):
             state.isCaptureCompleted = value
+        case .setIsWaiting(let isWaiting):
+            state.isWaiting = isWaiting
         }
         self.state = state
     }

--- a/mirroringBooth/mirroringBooth/Device/Remote/AppleWatch/WatchConnectionStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Remote/AppleWatch/WatchConnectionStore.swift
@@ -90,17 +90,21 @@ final class WatchConnectionStore: StoreProtocol {
 
     func reduce(_ result: Result) {
         var state = self.state
+
         switch result {
         case .setConnectionState(let value):
             state.connectionState = value
 
         case .setIsReadyToCapture(let value):
             state.isReadyToCapture = value
+
         case .setIsCaptureCompleted(let value):
             state.isCaptureCompleted = value
+
         case .setIsWaiting(let isWaiting):
             state.isWaiting = isWaiting
         }
+
         self.state = state
     }
 }

--- a/mirroringBooth/mirroringBooth/Device/Remote/AppleWatch/WatchConnectionStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Remote/AppleWatch/WatchConnectionStore.swift
@@ -73,11 +73,14 @@ final class WatchConnectionStore: StoreProtocol {
             Task { [weak self] in
                 await self?.connectionManager.sendCaptureRequest()
             }
+
         case .disconnect:
             self.connectionManager.stop()
             return [.setConnectionState(.notConnected)]
+
         case .startConnecting:
             self.connectionManager.start()
+
         case .isWaitingChanged(let isWaiting):
             return [.setIsWaiting(isWaiting)]
         }

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertisingStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertisingStore.swift
@@ -32,7 +32,7 @@ final class AdvertisingStore: StoreProtocol {
         case setShowTutorial(Bool)
     }
 
-    var state: State = .init()
+    private(set) var state: State = .init()
     let advertiser: Advertiser
     private var commandTask: Task<Void, Never>?
 

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertisingStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertisingStore.swift
@@ -22,7 +22,7 @@ final class AdvertisingStore: StoreProtocol {
         case entry
         case exit
         case connected
-        case setShowTutorial(Bool)
+        case showTutorial(Bool)
     }
 
     enum Result {
@@ -55,7 +55,7 @@ final class AdvertisingStore: StoreProtocol {
             advertiser.stopSearching(onlyRefuse: true)
             return [.setIsConnected(true)]
 
-        case .setShowTutorial(let value):
+        case .showTutorial(let value):
             return [.setShowTutorial(value)]
         }
 

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertisingStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertisingStore.swift
@@ -50,7 +50,6 @@ final class AdvertisingStore: StoreProtocol {
         case .exit:
             commandTask?.cancel()
             advertiser.stopSearching()
-            return []
 
         case .connected:
             advertiser.stopSearching(onlyRefuse: true)
@@ -59,6 +58,8 @@ final class AdvertisingStore: StoreProtocol {
         case .setShowTutorial(let value):
             return [.setShowTutorial(value)]
         }
+
+        return []
     }
 
     func reduce(_ result: Result) {
@@ -67,6 +68,7 @@ final class AdvertisingStore: StoreProtocol {
         switch result {
         case .setIsConnected(let bool):
             state.isConnected = bool
+
         case .setOnNavigate(let status, let useType):
             state.onNavigate = status
             state.deviceUseType = useType

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertisingStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertisingStore.swift
@@ -19,9 +19,9 @@ final class AdvertisingStore: StoreProtocol {
     }
 
     enum Intent {
-        case onAppear
-        case connected
+        case entry
         case exit
+        case connected
         case setShowTutorial(Bool)
     }
 
@@ -43,18 +43,18 @@ final class AdvertisingStore: StoreProtocol {
 
     func action(_ intent: Intent) -> [Result] {
         switch intent {
-        case .onAppear:
+        case .entry:
             advertiser.startSearching()
             return [.setOnNavigate(false, type: nil)]
-
-        case .connected:
-            advertiser.stopSearching(onlyRefuse: true)
-            return [.setIsConnected(true)]
 
         case .exit:
             commandTask?.cancel()
             advertiser.stopSearching()
             return []
+
+        case .connected:
+            advertiser.stopSearching(onlyRefuse: true)
+            return [.setIsConnected(true)]
 
         case .setShowTutorial(let value):
             return [.setShowTutorial(value)]

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertisingView.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertisingView.swift
@@ -86,7 +86,7 @@ struct AdvertisingView: View {
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 Button {
-                    store.send(.setShowTutorial(true))
+                    store.send(.showTutorial(true))
                 } label: {
                     Image(systemName: "questionmark.circle")
                 }
@@ -94,7 +94,7 @@ struct AdvertisingView: View {
         }
         .tutorialOverlay(isPresented: Binding(
             get: { store.state.showTutorial },
-            set: { store.send(.setShowTutorial($0)) }
+            set: { store.send(.showTutorial($0)) }
         ))
     }
 }

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertisingView.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/AdvertisingView.swift
@@ -55,7 +55,7 @@ struct AdvertisingView: View {
             .padding(20)
         }
         .onAppear {
-            store.send(.onAppear)
+            store.send(.entry)
             rootStore.advertiser = store.advertiser
         }
         .onDisappear {


### PR DESCRIPTION
## 🔗 연관된 이슈

- closed #277

## 📝 작업 내용

### 📌 요약

- `Store`의 `state` 모두 `private(set)`으로 지정
- `store`가 있는 `view`의 속성 간소화
- `action()` 메소드 `Result`을 바로 반환하는 방식으로 통일
- 기타 작업…

### 🔍 상세

> 요약에 있는 건 미리 팀에서 상의된 내용이어서 요약에 적은 내용을 제외하고 아래 설명을 적었습니다.
> 
1. 각 `Store`의 속성 순서 정렬
    - `state`가 항상 위에 있도록 수정
    - `state` 밑에는 `private` 속성들 먼저 위치
    
    ```swift
    // 예시 - StreamingStore
    private(set) var state: State
    private let advertiser: Advertiser?
    private let decoder: H264Decoder
    private var timer: Timer?
    
    let isTimerMode: Bool
    ```
    
2. `PhotoCompositionView`의 `reduce` 간소화
    - 기존에는 `reduce`에 비즈니스 로직이 포함되어있었습니다.
    - 해당 로직을 `action`으로 옮겨 `reduce`는 상태 변화를 담당하는 순수 함수의 특징을 가지도록 수정했습니다.
3. Intent, Result 각각의 네이밍 통일
    - `Intent`: `show~` / `Result`: `setShow~`
    - 예: `showAlert` / `setShowAlert`

## 💬 리뷰 노트

이전에 작성한 테스트 코드를 모두 통과하는 상태입니다.

더해서 전체 플로우를 실행했을 때도 문제 없이 돌아가는 것을 확인했습니다!