### PR TITLE
feat: 워치를 상시 리스트에 띄우고 미러링 기기로 선택 시 토스트를 띄우도록 변경

### DIFF
--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowsingStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowsingStore.swift
@@ -39,7 +39,7 @@ final class BrowsingStore: StoreProtocol {
         case cancel
         case didChangeAppState(UIApplication.State)
         case setShowMirroringDisconnectedAlert(Bool)
-        case setShowToast(Bool)
+        case setShowToast(Bool, String = "")
         case setShowTutorial(Bool)
         case browserEvent(BrowsingEvents)
     }
@@ -53,7 +53,7 @@ final class BrowsingStore: StoreProtocol {
         case setCurrentTarget(DeviceUseType)
         case startAnimation
         case setShowMirroringDisconnectedAlert(Bool)
-        case setShowToast(Bool)
+        case setShowToast(Bool, String)
         case setShowTutorial(Bool)
     }
 
@@ -213,7 +213,11 @@ final class BrowsingStore: StoreProtocol {
             // 2. 연결된 기기와 다른 기기를 선택했을 경우 연결 요청 전송
             if currentDevice != device {
                 if device.type == .watch {
-                    watchConnectionManager.sendConnectionRequest()
+                    if state.currentTarget == .mirroring {
+                        return [.setShowToast(true, "Apple Watch는 리모트 기기로만 연결할 수 있습니다.")]
+                    } else {
+                        watchConnectionManager.sendConnectionRequest()
+                    }
                 } else {
                     browser.connect(to: device.id, as: state.currentTarget)
                     result.append(.setIsConnecting(true))
@@ -243,8 +247,8 @@ final class BrowsingStore: StoreProtocol {
         case .setShowMirroringDisconnectedAlert(let value):
             result.append(.setShowMirroringDisconnectedAlert(value))
 
-        case .setShowToast(let value):
-            result.append(.setShowToast(value))
+        case .setShowToast(let value, let message):
+            result.append(.setShowToast(value, message))
 
         case .setShowTutorial(let value):
             result.append(.setShowTutorial(value))
@@ -306,7 +310,8 @@ final class BrowsingStore: StoreProtocol {
         case .setShowMirroringDisconnectedAlert(let alert):
             state.showMirroringDisconnectedAlert = alert
 
-        case .setShowToast(let value):
+        case .setShowToast(let value, let message):
+            state.toastMessage = message
             state.showToast = value
 
         case let .setShowTutorial(bool):

--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowsingView.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/BrowsingView.swift
@@ -53,21 +53,17 @@ struct BrowsingView: View {
                     LazyVStack {
                         ForEach(store.state.discoveredDevices) { device in
                             if device.type != .unknown {
-                                if store.state.currentTarget == .remote || (
-                                    store.state.currentTarget == .mirroring && device.type != .watch
-                                ) {
-                                    Button {
-                                        if !store.state.isConnecting {
-                                            store.send(.didSelect(device))
-                                        }
-                                    } label: {
-                                        DeviceRow(
-                                            device: device,
-                                            selectedTarget: isDeviceSelected(device)
-                                        )
+                                Button {
+                                    if !store.state.isConnecting {
+                                        store.send(.didSelect(device))
                                     }
-                                    .disabled(!isDeviceSelectable(device))
+                                } label: {
+                                    DeviceRow(
+                                        device: device,
+                                        selectedTarget: isDeviceSelected(device)
+                                    )
                                 }
+                                .disabled(!isDeviceSelectable(device))
                             }
                         }
                     }


### PR DESCRIPTION
## 🔗 연관된 이슈
- closed #294

## 📝 작업 내용

### 📌 요약 && 🔍 상세
- 워치가 미러링 기기 리스트에서도 보여주는 것으로 변경
- 미러링 기기로 워치 선택 시 토스트를 띄움

## 💬 리뷰 노트
> 애플 리젝으로 인한 변경입니다

## 📸 영상 / 이미지 (Optional)

https://github.com/user-attachments/assets/b0aa8200-9138-4d82-a778-4f087ac47c35