### PR TITLE
[#282] 촬영된 이미지 저장하고 전송하는 구간의 메모리 사용을 줄인다.

### DIFF
--- a/mirroringBooth/StoreTests/CameraPreviewStoreTests.swift
+++ b/mirroringBooth/StoreTests/CameraPreviewStoreTests.swift
@@ -14,7 +14,7 @@ final class MockCameraManager: CameraManageable {
     var rawData: ((CMSampleBuffer) -> Void)?
     var onEncodedData: ((Data) -> Void)?
     var onTransferCompleted: (() -> Void)?
-    var onAllPhotosStored: ((Int) -> Void)?
+    var onAllPhotosStored: (() -> Void)?
 
     private(set) var startSessionCallCount = 0
     private(set) var stopSessionCallCount = 0

--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/Browser.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/Browser.swift
@@ -208,41 +208,30 @@ final class Browser: NSObject {
     }
 
     /// 미러링 세션에 연결된 피어에게 사진 리소스를 전송합니다.
-    func sendPhotoResource(_ data: Data) {
+    func sendPhotoResource(at fileURL: URL) {
         guard let mirroringSession else { return }
         guard let mirroringPeer = mirroringSession.connectedPeers.first else {
             logger.warning("사진 전송 실패: 미러링 세션에 연결된 피어가 없습니다.")
             return
         }
 
-        let photoID = UUID()
-        let fileName = "\(photoID.uuidString).jpg"
+        let fileName = fileURL.lastPathComponent
+        logger.info("사진 전송 시작: \(fileName)")
 
-        // 임시 파일 생성
-        let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(fileName)
-
-        do {
-            try data.write(to: tempURL)
-            logger.info("사진 전송 시작: \(fileName) (\(data.count) bytes)")
-
-            mirroringSession.sendResource(
-                at: tempURL,
-                withName: fileName,
-                toPeer: mirroringPeer
-            ) { error in
-                if let error {
-                    self.logger.warning("사진 전송 실패 : \(error.localizedDescription)")
-                } else {
-                    self.cameraStreamEventContinuation.yield(.sendPhoto)
-                    self.logger.info("사진 전송 완료: \(fileName)")
-                }
-
-                // 전송 완료 후 임시 파일 삭제
-                try? FileManager.default.removeItem(at: tempURL)
+        mirroringSession.sendResource(
+            at: fileURL,
+            withName: fileName,
+            toPeer: mirroringPeer
+        ) { error in
+            if let error {
+                self.logger.warning("사진 전송 실패 : \(error.localizedDescription)")
+            } else {
+                self.cameraStreamEventContinuation.yield(.sendPhoto)
+                self.logger.info("사진 전송 완료: \(fileName)")
             }
 
-        } catch {
-            logger.warning("임시 파일 생성 실패 : \(error.localizedDescription)")
+            // 전송 완료 후 임시 파일 삭제
+            try? FileManager.default.removeItem(at: fileURL)
         }
     }
 

--- a/mirroringBooth/mirroringBooth/Device/Camera/Streaming/CameraManageable.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Streaming/CameraManageable.swift
@@ -11,7 +11,7 @@ protocol CameraManageable: AnyObject {
     var rawData: ((CMSampleBuffer) -> Void)? { get set }
     var onEncodedData: ((Data) -> Void)? { get set }
     var onTransferCompleted: (() -> Void)? { get set }
-    var onAllPhotosStored: ((Int) -> Void)? { get set }
+    var onAllPhotosStored: (() -> Void)? { get set }
 
     func startSession()
     func stopSession()

--- a/mirroringBooth/mirroringBooth/Device/Camera/Streaming/CameraManager/CameraManager.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Streaming/CameraManager/CameraManager.swift
@@ -74,6 +74,7 @@ final class CameraManager: NSObject, CameraManageable {
 
     /// 사진을 촬영합니다.
     func capturePhoto(_ orientation: CameraOrientation) {
+        guard capturedPhotoURLs.count < 10 else { return }
         DispatchQueue.main.async {
             self.logger.info("capturePhoto() 호출됨 - 촬영 시작")
             // JPEG 포맷으로 사진 촬영

--- a/mirroringBooth/mirroringBooth/Device/Camera/Streaming/CameraManager/CameraManager.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Streaming/CameraManager/CameraManager.swift
@@ -32,17 +32,14 @@ final class CameraManager: NSObject, CameraManageable {
         set { encoder.onEncodedData = newValue }
     }
 
-    /// 촬영된 이미지 데이터 콜백
-    var onCapturedPhoto: ((Data) -> Void)?
-
     /// 전송 완료 콜백
     var onTransferCompleted: (() -> Void)?
 
     /// 10장 저장 완료 콜백 (타이머 모드에서 10장 모두 저장되면 호출)
-    var onAllPhotosStored: ((Int) -> Void)?
+    var onAllPhotosStored: (() -> Void)?
 
-    // 촬영된 이미지 임시 저장 배열
-    private var capturedPhotos: [Data] = []
+    // 촬영된 이미지 임시 파일 URL 배열
+    private var capturedPhotoURLs: [URL] = []
 
     // 현재 전송 진행 상황
     var transferProgress: (current: Int, total: Int) = (0, 0)
@@ -98,7 +95,7 @@ final class CameraManager: NSObject, CameraManageable {
 
     /// 저장된 사진을 일괄 전송합니다.
     func sendAllPhotos(using browser: Browser) {
-        let total = capturedPhotos.count
+        let total = capturedPhotoURLs.count
         guard total > 0 else {
             logger.warning("전송할 사진이 없습니다.")
             return
@@ -108,16 +105,16 @@ final class CameraManager: NSObject, CameraManageable {
         logger.info("일괄 전송 시작: \(total)장")
 
         Task { @MainActor in
-            for (index, photoData) in capturedPhotos.enumerated() {
-                browser.sendPhotoResource(photoData)
+            for (index, photoURL) in capturedPhotoURLs.enumerated() {
+                browser.sendPhotoResource(at: photoURL)
 
                 transferProgress = (index + 1, total)
 
                 try? await Task.sleep(nanoseconds: 100_000_000) // 0.1초 짧게 대기
             }
 
-            // 전송 완료 처리
-            capturedPhotos.removeAll()
+            // 전송 완료 처리 (임시 파일 삭제는 Browser에서 전송 완료 후 처리)
+            capturedPhotoURLs.removeAll()
             transferProgress = (0, 0)
             logger.info("일괄 전송 완료")
             onTransferCompleted?()
@@ -297,19 +294,27 @@ extension CameraManager: AVCapturePhotoCaptureDelegate {
         }
     }
 
-    /// 촬영된 사진 데이터를 저장하고 콜백을 호출합니다.
+    /// 촬영된 사진 데이터를 임시 파일로 저장하고 콜백을 호출합니다.
     private func storePhotoData(_ photoData: Data) {
-        DispatchQueue.main.async {
-            self.capturedPhotos.append(photoData)
-            let storedCount = self.capturedPhotos.count
+        // 임시 파일로 저장 
+        let fileName = "\(UUID().uuidString).jpg"
+        let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(fileName)
 
-            // 수동 촬영 버튼용 콜백
-            // self.onCapturedPhoto?(photoData)
+        do {
+            try photoData.write(to: tempURL)
+            logger.info("사진 임시 저장 완료: \(fileName) (\(photoData.count) bytes)")
 
-            // 10장 모두 저장되면 콜백 호출
-            if storedCount == 10 {
-                self.onAllPhotosStored?(storedCount)
+            DispatchQueue.main.async {
+                self.capturedPhotoURLs.append(tempURL)
+                let storedCount = self.capturedPhotoURLs.count
+
+                // 10장 모두 저장되면 콜백 호출
+                if storedCount == 10 {
+                    self.onAllPhotosStored?()
+                }
             }
+        } catch {
+            logger.warning("사진 임시 파일 저장 실패: \(error.localizedDescription)")
         }
     }
 

--- a/mirroringBooth/mirroringBooth/Device/Camera/Streaming/CameraPreviewStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Streaming/CameraPreviewStore.swift
@@ -152,7 +152,7 @@ private extension CameraPreviewStore {
         }
 
         // 10장 모두 저장 완료 시 미러링기기에 알림 전송
-        cameraManager.onAllPhotosStored = { [weak self] _ in
+        cameraManager.onAllPhotosStored = { [weak self] in
             Task { @MainActor in
                 self?.browser.sendCommand(.onStoreAllPhotos)
                 self?.reduce(.captureCompleted)


### PR DESCRIPTION
## 🔗 연관된 이슈

- closed #282

## 📝 작업 내용

### 📌 요약

- 촬영 사진 전송 과정의 메모리 사용 개선
- 촬영 버튼 연타 시 발생한 버그 해결

### 🔍 상세

**메모리 사용 개선**

기존: `사진 촬영` → `메모리에 Data 저장` → (촬영 완료) → `저장한 Data 임시 파일에 생성` → `임시 파일 전송`

변경: `사진 촬영` → `임시 파일 생성` → (촬영 완료) → `임시 파일 전송`

> 임시로 메모리 사용을 보여주는 UI를 만들고 개선 전과 후를 비교해봤습니다.  
맨 아래 영상을 첨부했는데 **1-5장은 메모리 관찰하면서 천천히**, **6-10장은 빠르게 연타하며 비교했음**을 참고해주세요!
> 
1. 사진 촬영마다 증가하는 메모리가 감소했습니다.
2. 완료 화면에서 홈 화면으로 돌아갈 때 메모리가 해제되는 속도가 빨라졌습니다.
3. 사진 전송 속도는 두 버전 모두 실행할 때마다 달랐고, 별 차이 없었습니다.
    - 첨부한 영상은 이전 버전이 전송 속도가 더 빨라보이지만, 현재 버전이 더 빨랐을 때도 있습니다.

**👉 문제 없이 잘 돌아가던 로직이지만, 이 개선을 통해 실제로 메모리 사용이 줄었음을 확인할 수 있습니다.**

## 💬 리뷰 노트

### 버그 해결

**1️⃣ 문제 상황**

비교 영상을 녹화하면서, 촬영 버튼을 빠르게 연타하다가 버그 하나를 발견했습니다.

기존에 촬영 버튼에 디바운싱이 있어 빠르게 누르는만큼 모두 촬영 요청이 가지는 않았습니다.

그런데 촬영이 끝나갈 때 쯤, 즉 **마지막 사진 촬영 때 버튼을 빠르게 누르면 촬영 요청이 한 번 더 가는 현상을 확인했습니다.**

(찰칵 소리가 한 번 더 들리는 상황)

이런 상황이 발생하면, 촬영 기기에서 `사진 전송 중 오버레이`가 10/10까지 올라간 후 화면이 전환되지 않고 계속 오버레이 화면에 머무는 문제가 발생했습니다.

미러링 기기에서는 수신 오버레이가 잘 내려가고, 의도대로 잘 동작했습니다.

**2️⃣ 해결**

기기 간 명령어를 전달하면서 로직을 제어하다보니 타이밍에 오류가 있다고 판단했습니다.

`CameraManager`에서 사진을 촬영하는 메소드 `capturePhoto(_:)`에서 촬영된 사진이 10장 미만일 경우만 촬영을 진행하도록 `guard`문을 추가했습니다.

```swift
/// 사진을 촬영합니다.
func capturePhoto(_ orientation: CameraOrientation) {
    guard capturedPhotoURLs.count < 10 else { return }
    DispatchQueue.main.async {
        self.logger.info("capturePhoto() 호출됨 - 촬영 시작")
        ...
    }
}
```

## 📸 영상 / 이미지

### 개선 전과 후 비교
> 영상 크기 때문에 해상도를 조절해서 좀 어긋나보입니다 😅

| - | Before | After |
| -- | -- | -- |
| 메모리 증가 비교 (천천히) | ![282-before-slow](https://github.com/user-attachments/assets/d99811d1-da2f-4b36-a1eb-9828d225d7fd) | ![282-after-slow](https://github.com/user-attachments/assets/8e824eb9-25cb-422d-acc4-b7d5a8b0fcb1) |
| 메모리 튀는지 확인 (빠르게) | ![282-before-fast](https://github.com/user-attachments/assets/7c8fd054-eaf8-4a7b-8659-17b5c926af48) | ![282-after-fast](https://github.com/user-attachments/assets/a3d93af0-09b4-4dab-961f-be3e6a06d584) |
| 메모리 해제 속도 | ![282-before-end](https://github.com/user-attachments/assets/9fa35fec-ed99-411c-8452-deb6e4148c62) | ![282-after-end](https://github.com/user-attachments/assets/9bc3c27a-2836-4cb5-aacf-48b828b497dd) |

### 버그 발생 화면

https://github.com/user-attachments/assets/c98f9e0b-5205-4927-9b25-e833544fc61f

