### PR TITLE
[Test/#288] Browser의 테스트 코드를 작성한다. 

### DIFF
--- a/mirroringBooth/mirroringBooth.xcodeproj/xcshareddata/xcschemes/mirroringBoothTests.xcscheme
+++ b/mirroringBooth/mirroringBooth.xcodeproj/xcshareddata/xcschemes/mirroringBoothTests.xcscheme
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2610"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0C2009832F306ED700B6197B"
+               BuildableName = "mirroringBoothTests.xctest"
+               BlueprintName = "mirroringBoothTests"
+               ReferencedContainer = "container:mirroringBooth.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/mirroringBooth/mirroringBoothTests/BrowserTests.swift
+++ b/mirroringBooth/mirroringBoothTests/BrowserTests.swift
@@ -196,7 +196,7 @@ struct BrowserTests {
         await collector.startCollecting(streamType: .cameraStream)
 
         // WHEN - Advertiser.CameraDeviceCommand.capturePhoto 명령 수신 시뮬레이션
-        let commandData = "capturePhoto".data(using: .utf8)!
+        let commandData = Data("capturePhoto".utf8)
         browser.session(mockSession, didReceive: commandData, fromPeer: testPeerID)
 
         // THEN
@@ -217,7 +217,7 @@ struct BrowserTests {
         await collector.startCollecting(streamType: .cameraStream)
 
         // WHEN - Advertiser.CameraDeviceCommand.startTransfer 명령 수신 시뮬레이션
-        let commandData = "startTransfer".data(using: .utf8)!
+        let commandData = Data("startTransfer".utf8)
         browser.session(mockSession, didReceive: commandData, fromPeer: testPeerID)
 
         // THEN
@@ -236,7 +236,7 @@ struct BrowserTests {
         let mockSession = MCSession(peer: testPeerID, securityIdentity: nil, encryptionPreference: .none)
 
         // WHEN - heartBeat 명령 수신 (크래시 없이 처리되면 성공)
-        let commandData = "heartBeat".data(using: .utf8)!
+        let commandData = Data("heartBeat".utf8)
         browser.session(mockSession, didReceive: commandData, fromPeer: testPeerID)
 
         // THEN - 크래시 없이 처리되면 성공
@@ -250,7 +250,7 @@ struct BrowserTests {
         let mockSession = MCSession(peer: testPeerID, securityIdentity: nil, encryptionPreference: .none)
 
         // WHEN - 알 수 없는 명령 수신
-        let commandData = "unknownCommand".data(using: .utf8)!
+        let commandData = Data("unknownCommand".utf8)
         browser.session(mockSession, didReceive: commandData, fromPeer: testPeerID)
 
         // THEN - 크래시 없이 처리되면 성공

--- a/mirroringBooth/mirroringBoothTests/BrowserTests.swift
+++ b/mirroringBooth/mirroringBoothTests/BrowserTests.swift
@@ -216,7 +216,7 @@ struct BrowserTests {
 
         await collector.startCollecting(streamType: .cameraStream)
 
-        // WHEN - Advertiser.CameraDeviceCommand.startTransfer 명령 수신 시뮬레이션
+        // WHEN - Advertiser.CameraDeviceCommand.startTransfer 명령 수신을 시뮬레이션 합니다.
         let commandData = Data("startTransfer".utf8)
         browser.session(mockSession, didReceive: commandData, fromPeer: testPeerID)
 
@@ -278,39 +278,6 @@ struct BrowserTests {
         #expect(events.count == 1)
         guard case .heartbeatTimeout = events.first else {
             Issue.record("Expected .heartbeatTimeout event, got: \(String(describing: events.first))")
-            return
-        }
-    }
-
-    @Test func remoteHeartbeat_타임아웃시_remoteHeartbeatTimeout_이벤트가_발생한다() async {
-        // GIVEN
-        let browser = Browser()
-        // remoteHeartBeater 생성을 위해 connect 시뮬레이션이 필요하지만,
-        // 직접 테스트하기 어려우므로 remoteHeartBeater가 nil인 경우 스킵
-
-        guard let remoteHeartBeater = browser.remoteHeartBeater else {
-            // remoteHeartBeater가 nil이면 이 테스트는 의미가 없음
-            // 리팩터링 후 BrowserCommandManager에서 테스트 예정
-            #expect(true, "remoteHeartBeater가 nil이므로 스킵")
-            return
-        }
-
-        let heartbeatCollector = HeartbeatEventCollector(
-            browsingStream: browser.browsingHeartbeatStream,
-            connectionCheckStream: browser.connectionCheckHeartbeatStream,
-            cameraPreviewStream: browser.cameraPreviewHeartbeatStream
-        )
-
-        await heartbeatCollector.startCollecting(streamType: .browsing)
-
-        // WHEN - remoteHeartBeater 타임아웃 시뮬레이션
-        browser.onTimeout(remoteHeartBeater)
-
-        // THEN
-        let events = await heartbeatCollector.collectEvents(count: 1, timeout: 0.5)
-        #expect(events.count == 1)
-        guard case .remoteHeartbeatTimeout = events.first else {
-            Issue.record("Expected .remoteHeartbeatTimeout event, got: \(String(describing: events.first))")
             return
         }
     }
@@ -441,7 +408,7 @@ actor EventCollector {
     }
 }
 
-// MARK: - Heartbeat Event Collector (Test Helper)
+// MARK: - Heartbeat Event Collector
 
 /// Heartbeat 이벤트 스트림을 수집하는 테스트 헬퍼
 actor HeartbeatEventCollector {

--- a/mirroringBooth/mirroringBoothTests/BrowserTests.swift
+++ b/mirroringBooth/mirroringBoothTests/BrowserTests.swift
@@ -185,16 +185,172 @@ struct BrowserTests {
         #expect(true)
     }
 
-    // MARK: - TODO
+    // MARK: - 명령 수신 (executeCommand) 테스트
 
-    // executeCommand는 현재 private이므로 리팩터링 후
-    // BrowserCommandManager를 통해 명령 수신 테스트 진행 예정입니다.
+    @Test func capturePhoto_명령_수신시_captureCommand_이벤트가_발생한다() async {
+        // GIVEN
+        let (browser, collector) = makeSUT()
+        let testPeerID = MCPeerID(displayName: "테스트기기")
+        let mockSession = MCSession(peer: testPeerID, securityIdentity: nil, encryptionPreference: .none)
 
-    // MCSession 의존성 주입이 필요하므로 리팩터링 후
-    // 연결 상태 변경(deviceConnected, deviceConnectionFailed) 테스트 진행 예정입니다.
+        await collector.startCollecting(streamType: .cameraStream)
 
-    // sendPhotoResource 완료 이벤트(.sendPhoto)는
-    // 실제 MCSession.sendResource 콜백이 필요하므로 리팩터링 후 테스트 진행 예정입니다.
+        // WHEN - Advertiser.CameraDeviceCommand.capturePhoto 명령 수신 시뮬레이션
+        let commandData = "capturePhoto".data(using: .utf8)!
+        browser.session(mockSession, didReceive: commandData, fromPeer: testPeerID)
+
+        // THEN
+        let events = await collector.collectCameraStreamEvents(count: 1, timeout: 0.5)
+        #expect(events.count == 1)
+        guard case .captureCommand = events.first else {
+            Issue.record("Expected .captureCommand event, got: \(String(describing: events.first))")
+            return
+        }
+    }
+
+    @Test func startTransfer_명령_수신시_startTransfer_이벤트가_발생한다() async {
+        // GIVEN
+        let (browser, collector) = makeSUT()
+        let testPeerID = MCPeerID(displayName: "테스트기기")
+        let mockSession = MCSession(peer: testPeerID, securityIdentity: nil, encryptionPreference: .none)
+
+        await collector.startCollecting(streamType: .cameraStream)
+
+        // WHEN - Advertiser.CameraDeviceCommand.startTransfer 명령 수신 시뮬레이션
+        let commandData = "startTransfer".data(using: .utf8)!
+        browser.session(mockSession, didReceive: commandData, fromPeer: testPeerID)
+
+        // THEN
+        let events = await collector.collectCameraStreamEvents(count: 1, timeout: 0.5)
+        #expect(events.count == 1)
+        guard case .startTransfer = events.first else {
+            Issue.record("Expected .startTransfer event, got: \(String(describing: events.first))")
+            return
+        }
+    }
+
+    @Test func heartBeat_명령_수신시_HeartBeater가_beat를_호출한다() async {
+        // GIVEN
+        let (browser, _) = makeSUT()
+        let testPeerID = MCPeerID(displayName: "테스트기기")
+        let mockSession = MCSession(peer: testPeerID, securityIdentity: nil, encryptionPreference: .none)
+
+        // WHEN - heartBeat 명령 수신 (크래시 없이 처리되면 성공)
+        let commandData = "heartBeat".data(using: .utf8)!
+        browser.session(mockSession, didReceive: commandData, fromPeer: testPeerID)
+
+        // THEN - 크래시 없이 처리되면 성공
+        #expect(true)
+    }
+
+    @Test func 알_수_없는_명령_수신시_크래시하지_않는다() async {
+        // GIVEN
+        let (browser, _) = makeSUT()
+        let testPeerID = MCPeerID(displayName: "테스트기기")
+        let mockSession = MCSession(peer: testPeerID, securityIdentity: nil, encryptionPreference: .none)
+
+        // WHEN - 알 수 없는 명령 수신
+        let commandData = "unknownCommand".data(using: .utf8)!
+        browser.session(mockSession, didReceive: commandData, fromPeer: testPeerID)
+
+        // THEN - 크래시 없이 처리되면 성공
+        #expect(true)
+    }
+
+    // MARK: - Heartbeat 타임아웃 테스트
+
+    @Test func mirroringHeartbeat_타임아웃시_heartbeatTimeout_이벤트가_발생한다() async {
+        // GIVEN
+        let (browser, _) = makeSUT()
+        let heartbeatCollector = HeartbeatEventCollector(
+            browsingStream: browser.browsingHeartbeatStream,
+            connectionCheckStream: browser.connectionCheckHeartbeatStream,
+            cameraPreviewStream: browser.cameraPreviewHeartbeatStream
+        )
+
+        await heartbeatCollector.startCollecting(streamType: .browsing)
+
+        // WHEN - mirroringHeartBeater 타임아웃 시뮬레이션
+        browser.onTimeout(browser.mirroringHeartBeater)
+
+        // THEN
+        let events = await heartbeatCollector.collectEvents(count: 1, timeout: 0.5)
+        #expect(events.count == 1)
+        guard case .heartbeatTimeout = events.first else {
+            Issue.record("Expected .heartbeatTimeout event, got: \(String(describing: events.first))")
+            return
+        }
+    }
+
+    @Test func remoteHeartbeat_타임아웃시_remoteHeartbeatTimeout_이벤트가_발생한다() async {
+        // GIVEN
+        let browser = Browser()
+        // remoteHeartBeater 생성을 위해 connect 시뮬레이션이 필요하지만,
+        // 직접 테스트하기 어려우므로 remoteHeartBeater가 nil인 경우 스킵
+
+        guard let remoteHeartBeater = browser.remoteHeartBeater else {
+            // remoteHeartBeater가 nil이면 이 테스트는 의미가 없음
+            // 리팩터링 후 BrowserCommandManager에서 테스트 예정
+            #expect(true, "remoteHeartBeater가 nil이므로 스킵")
+            return
+        }
+
+        let heartbeatCollector = HeartbeatEventCollector(
+            browsingStream: browser.browsingHeartbeatStream,
+            connectionCheckStream: browser.connectionCheckHeartbeatStream,
+            cameraPreviewStream: browser.cameraPreviewHeartbeatStream
+        )
+
+        await heartbeatCollector.startCollecting(streamType: .browsing)
+
+        // WHEN - remoteHeartBeater 타임아웃 시뮬레이션
+        browser.onTimeout(remoteHeartBeater)
+
+        // THEN
+        let events = await heartbeatCollector.collectEvents(count: 1, timeout: 0.5)
+        #expect(events.count == 1)
+        guard case .remoteHeartbeatTimeout = events.first else {
+            Issue.record("Expected .remoteHeartbeatTimeout event, got: \(String(describing: events.first))")
+            return
+        }
+    }
+
+    @Test func heartbeat_타임아웃시_모든_스트림에_이벤트가_전달된다() async {
+        // GIVEN
+        let (browser, _) = makeSUT()
+
+        let browsingCollector = HeartbeatEventCollector(
+            browsingStream: browser.browsingHeartbeatStream,
+            connectionCheckStream: browser.connectionCheckHeartbeatStream,
+            cameraPreviewStream: browser.cameraPreviewHeartbeatStream
+        )
+        let connectionCheckCollector = HeartbeatEventCollector(
+            browsingStream: browser.browsingHeartbeatStream,
+            connectionCheckStream: browser.connectionCheckHeartbeatStream,
+            cameraPreviewStream: browser.cameraPreviewHeartbeatStream
+        )
+        let cameraPreviewCollector = HeartbeatEventCollector(
+            browsingStream: browser.browsingHeartbeatStream,
+            connectionCheckStream: browser.connectionCheckHeartbeatStream,
+            cameraPreviewStream: browser.cameraPreviewHeartbeatStream
+        )
+
+        await browsingCollector.startCollecting(streamType: .browsing)
+        await connectionCheckCollector.startCollecting(streamType: .connectionCheck)
+        await cameraPreviewCollector.startCollecting(streamType: .cameraPreview)
+
+        // WHEN
+        browser.onTimeout(browser.mirroringHeartBeater)
+
+        // THEN - 모든 스트림에서 이벤트 수신
+        let browsingEvents = await browsingCollector.collectEvents(count: 1, timeout: 0.5)
+        let connectionCheckEvents = await connectionCheckCollector.collectEvents(count: 1, timeout: 0.5)
+        let cameraPreviewEvents = await cameraPreviewCollector.collectEvents(count: 1, timeout: 0.5)
+
+        #expect(browsingEvents.count == 1, "browsingHeartbeatStream에서 이벤트 수신 실패")
+        #expect(connectionCheckEvents.count == 1, "connectionCheckHeartbeatStream에서 이벤트 수신 실패")
+        #expect(cameraPreviewEvents.count == 1, "cameraPreviewHeartbeatStream에서 이벤트 수신 실패")
+    }
 }
 
 // MARK: - Event Collector (Test Helper)
@@ -282,5 +438,71 @@ actor EventCollector {
     func reset() {
         browsingEvents.removeAll()
         cameraStreamEvents.removeAll()
+    }
+}
+
+// MARK: - Heartbeat Event Collector (Test Helper)
+
+/// Heartbeat 이벤트 스트림을 수집하는 테스트 헬퍼
+actor HeartbeatEventCollector {
+    enum StreamType {
+        case browsing
+        case connectionCheck
+        case cameraPreview
+    }
+
+    private let browsingStream: AsyncStream<HeartBeatEvents>
+    private let connectionCheckStream: AsyncStream<HeartBeatEvents>
+    private let cameraPreviewStream: AsyncStream<HeartBeatEvents>
+    private var events: [HeartBeatEvents] = []
+    private var task: Task<Void, Never>?
+
+    init(
+        browsingStream: AsyncStream<HeartBeatEvents>,
+        connectionCheckStream: AsyncStream<HeartBeatEvents>,
+        cameraPreviewStream: AsyncStream<HeartBeatEvents>
+    ) {
+        self.browsingStream = browsingStream
+        self.connectionCheckStream = connectionCheckStream
+        self.cameraPreviewStream = cameraPreviewStream
+    }
+
+    deinit {
+        task?.cancel()
+    }
+
+    func startCollecting(streamType: StreamType) {
+        let stream: AsyncStream<HeartBeatEvents>
+        switch streamType {
+        case .browsing:
+            stream = browsingStream
+        case .connectionCheck:
+            stream = connectionCheckStream
+        case .cameraPreview:
+            stream = cameraPreviewStream
+        }
+
+        task = Task { [weak self] in
+            guard let self else { return }
+            for await event in stream {
+                await self.appendEvent(event)
+            }
+        }
+    }
+
+    private func appendEvent(_ event: HeartBeatEvents) {
+        events.append(event)
+    }
+
+    func collectEvents(count: Int, timeout: TimeInterval) async -> [HeartBeatEvents] {
+        let deadline = Date().addingTimeInterval(timeout)
+        while events.count < count && Date() < deadline {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        return events
+    }
+
+    func reset() {
+        events.removeAll()
     }
 }

--- a/mirroringBooth/mirroringBoothTests/BrowserTests.swift
+++ b/mirroringBooth/mirroringBoothTests/BrowserTests.swift
@@ -185,50 +185,6 @@ struct BrowserTests {
         #expect(true)
     }
 
-    // MARK: - 명령 수신 (executeCommand) 테스트
-
-    @Test func capturePhoto_명령_수신시_captureCommand_이벤트가_발생한다() async {
-        // GIVEN
-        let (browser, collector) = makeSUT()
-        let testPeerID = MCPeerID(displayName: "테스트기기")
-        let mockSession = MCSession(peer: testPeerID, securityIdentity: nil, encryptionPreference: .none)
-
-        await collector.startCollecting(streamType: .cameraStream)
-
-        // WHEN - Advertiser.CameraDeviceCommand.capturePhoto 명령 수신 시뮬레이션
-        let commandData = Data("capturePhoto".utf8)
-        browser.session(mockSession, didReceive: commandData, fromPeer: testPeerID)
-
-        // THEN
-        let events = await collector.collectCameraStreamEvents(count: 1, timeout: 0.5)
-        #expect(events.count == 1)
-        guard case .captureCommand = events.first else {
-            Issue.record("Expected .captureCommand event, got: \(String(describing: events.first))")
-            return
-        }
-    }
-
-    @Test func startTransfer_명령_수신시_startTransfer_이벤트가_발생한다() async {
-        // GIVEN
-        let (browser, collector) = makeSUT()
-        let testPeerID = MCPeerID(displayName: "테스트기기")
-        let mockSession = MCSession(peer: testPeerID, securityIdentity: nil, encryptionPreference: .none)
-
-        await collector.startCollecting(streamType: .cameraStream)
-
-        // WHEN - Advertiser.CameraDeviceCommand.startTransfer 명령 수신을 시뮬레이션 합니다.
-        let commandData = Data("startTransfer".utf8)
-        browser.session(mockSession, didReceive: commandData, fromPeer: testPeerID)
-
-        // THEN
-        let events = await collector.collectCameraStreamEvents(count: 1, timeout: 0.5)
-        #expect(events.count == 1)
-        guard case .startTransfer = events.first else {
-            Issue.record("Expected .startTransfer event, got: \(String(describing: events.first))")
-            return
-        }
-    }
-
     @Test func heartBeat_명령_수신시_HeartBeater가_beat를_호출한다() async {
         // GIVEN
         let (browser, _) = makeSUT()

--- a/mirroringBooth/mirroringBoothTests/BrowserTests.swift
+++ b/mirroringBooth/mirroringBoothTests/BrowserTests.swift
@@ -120,6 +120,7 @@ struct BrowserTests {
             Issue.record("Expected .captureCommand event, got: \(String(describing: events.first))")
             return
         }
+        #expect(true, "captureCommand 이벤트 확인 완료")
     }
 
     // MARK: - 명령 전송

--- a/mirroringBooth/mirroringBoothTests/BrowserTests.swift
+++ b/mirroringBooth/mirroringBoothTests/BrowserTests.swift
@@ -1,0 +1,286 @@
+//
+//  BrowserTest.swift
+//  mirroringBooth
+//
+//  Created by 윤대현 on 2/4/26.
+//
+
+import Testing
+import MultipeerConnectivity
+@testable import mirroringBooth
+
+// MARK: - Browser Tests
+/// AI를 활용해 작성했습니다.
+@MainActor
+struct BrowserTests {
+
+    private func makeSUT() -> (browser: Browser, eventCollector: EventCollector) {
+        let browser = Browser()
+        let collector = EventCollector(
+            browsingStream: browser.browsingEventStream,
+            cameraStream: browser.cameraStreamEventStream
+        )
+        return (browser, collector)
+    }
+
+    // MARK: - 기기 검색
+
+    @Test func 주변_기기를_발견하면_deviceFound_이벤트가_발생한다() async {
+        // GIVEN
+        let (browser, collector) = makeSUT()
+        let testPeerID = MCPeerID(displayName: "몽이")
+        let discoveryInfo = ["deviceType": "iPad"]
+
+        await collector.startCollecting(streamType: .browsing)
+
+        // WHEN
+        browser.browser(
+            MCNearbyServiceBrowser(peer: testPeerID, serviceType: "mirroringbooth"),
+            foundPeer: testPeerID,
+            withDiscoveryInfo: discoveryInfo
+        )
+
+        // THEN
+        let events = await collector.collectBrowsingEvents(count: 1, timeout: 0.5)
+        #expect(events.count == 1)
+        guard case .deviceFound(let device) = events.first else {
+            Issue.record("Expected .deviceFound event, got: \(String(describing: events.first))")
+            return
+        }
+        #expect(device.id == "몽이")
+        #expect(device.type == .iPad)
+    }
+
+    @Test func 주변_기기가_사라지면_deviceLost_이벤트가_발생한다() async {
+        // GIVEN
+        let (browser, collector) = makeSUT()
+        let testPeerID = MCPeerID(displayName: "몽이")
+        let discoveryInfo = ["deviceType": "iPad"]
+
+        // 기기 발견 시뮬레이션
+        browser.browser(
+            MCNearbyServiceBrowser(peer: testPeerID, serviceType: "mirroringbooth"),
+            foundPeer: testPeerID,
+            withDiscoveryInfo: discoveryInfo
+        )
+
+        // 첫 번째 이벤트 소비 후 수집 시작
+        await collector.startCollecting(streamType: .browsing, skipFirst: 1)
+
+        // WHEN
+        browser.browser(
+            MCNearbyServiceBrowser(peer: testPeerID, serviceType: "mirroringbooth"),
+            lostPeer: testPeerID
+        )
+
+        // THEN
+        let events = await collector.collectBrowsingEvents(count: 1, timeout: 0.5)
+        #expect(events.count == 1)
+        guard case .deviceLost(let device) = events.first else {
+            Issue.record("Expected .deviceLost event, got: \(String(describing: events.first))")
+            return
+        }
+        #expect(device.id == "몽이")
+    }
+
+    @Test func deviceType이_없는_기기는_발견_이벤트가_발생하지_않는다() async {
+        // GIVEN
+        let (browser, collector) = makeSUT()
+        let testPeerID = MCPeerID(displayName: "몽이")
+        let emptyDiscoveryInfo: [String: String] = [:]  // deviceType 없는 상태
+
+        await collector.startCollecting(streamType: .browsing)
+
+        // WHEN
+        browser.browser(
+            MCNearbyServiceBrowser(peer: testPeerID, serviceType: "mirroringbooth"),
+            foundPeer: testPeerID,
+            withDiscoveryInfo: emptyDiscoveryInfo
+        )
+
+        // THEN
+        let events = await collector.collectBrowsingEvents(count: 1, timeout: 0.3)
+        #expect(events.isEmpty, "deviceType 없이 발견된 기기는 이벤트가 발생하지 않아야 합니다.")
+    }
+
+    // MARK: - 카메라 스트림 이벤트 테스트
+
+    @Test func capturePhoto_호출시_captureCommand_이벤트가_발생한다() async {
+        // GIVEN
+        let (browser, collector) = makeSUT()
+        await collector.startCollecting(streamType: .cameraStream)
+
+        // WHEN
+        browser.capturePhoto()
+
+        // THEN
+        let events = await collector.collectCameraStreamEvents(count: 1, timeout: 0.5)
+        #expect(events.count == 1)
+        guard case .captureCommand = events.first else {
+            Issue.record("Expected .captureCommand event, got: \(String(describing: events.first))")
+            return
+        }
+    }
+
+    // MARK: - 명령 전송
+
+    @Test func 세션이_없을때_sendCommand는_실패해도_크래시하지_않는다() async {
+        // GIVEN
+        let (browser, _) = makeSUT()
+
+        // WHEN - mirroringCommandSession이 nil인 상태
+        browser.sendCommand(.heartBeat)
+
+        // THEN - 크래시하지 않으면 성공
+        #expect(true)
+    }
+
+    @Test func 세션이_없을때_sendRemoteCommand는_실패해도_크래시하지_않는다() async {
+        // GIVEN
+        let (browser, _) = makeSUT()
+
+        // WHEN - remoteSession이 nil인 상태
+        browser.sendRemoteCommand(.heartBeat)
+
+        // THEN - 크래시하지 않으면 성공
+        #expect(true)
+    }
+
+    @Test func 세션이_없을때_sendStreamData는_실패해도_크래시하지_않는다() async {
+        // GIVEN
+        let (browser, _) = makeSUT()
+        let testData = Data([0x01, 0x02, 0x03])
+
+        // WHEN - mirroringSession이 nil인 상태
+        browser.sendStreamData(testData)
+
+        // THEN - 크래시하지 않으면 성공
+        #expect(true)
+    }
+
+    // MARK: - 검색 시작/중지 및 연결 해제
+
+    @Test func startSearching_호출시_크래시하지_않는다() async {
+        // GIVEN
+        let (browser, _) = makeSUT()
+
+        // WHEN
+        browser.startSearching()
+
+        // THEN
+        #expect(true)
+
+        // Cleanup
+        browser.stopSearching()
+    }
+
+    @Test func disconnect_호출시_크래시하지_않는다() async {
+        // GIVEN
+        let (browser, _) = makeSUT()
+
+        // WHEN
+        browser.disconnect()
+
+        // THEN
+        #expect(true)
+    }
+
+    // MARK: - TODO
+
+    // executeCommand는 현재 private이므로 리팩터링 후
+    // BrowserCommandManager를 통해 명령 수신 테스트 진행 예정입니다.
+
+    // MCSession 의존성 주입이 필요하므로 리팩터링 후
+    // 연결 상태 변경(deviceConnected, deviceConnectionFailed) 테스트 진행 예정입니다.
+
+    // sendPhotoResource 완료 이벤트(.sendPhoto)는
+    // 실제 MCSession.sendResource 콜백이 필요하므로 리팩터링 후 테스트 진행 예정입니다.
+}
+
+// MARK: - Event Collector (Test Helper)
+
+/// 비동기 이벤트 스트림을 수집하는 테스트 헬퍼
+/// 실제 스트림을 소비하고 이벤트를 배열로 수집합니다.
+actor EventCollector {
+    enum StreamType {
+        case browsing
+        case cameraStream
+    }
+
+    private let browsingStream: AsyncStream<BrowsingEvents>
+    private let cameraStream: AsyncStream<CameraStreamEvents>
+    private var browsingEvents: [BrowsingEvents] = []
+    private var cameraStreamEvents: [CameraStreamEvents] = []
+    private var browsingTask: Task<Void, Never>?
+    private var cameraStreamTask: Task<Void, Never>?
+
+    init(
+        browsingStream: AsyncStream<BrowsingEvents>,
+        cameraStream: AsyncStream<CameraStreamEvents>
+    ) {
+        self.browsingStream = browsingStream
+        self.cameraStream = cameraStream
+    }
+
+    deinit {
+        browsingTask?.cancel()
+        cameraStreamTask?.cancel()
+    }
+
+    /// 이벤트 수집 시작
+    func startCollecting(streamType: StreamType, skipFirst: Int = 0) {
+        switch streamType {
+        case .browsing:
+            browsingTask = Task { [weak self] in
+                guard let self else { return }
+                var skipped = 0
+                for await event in browsingStream {
+                    if skipped < skipFirst {
+                        skipped += 1
+                        continue
+                    }
+                    await self.appendBrowsingEvent(event)
+                }
+            }
+        case .cameraStream:
+            cameraStreamTask = Task { [weak self] in
+                guard let self else { return }
+                for await event in cameraStream {
+                    await self.appendCameraStreamEvent(event)
+                }
+            }
+        }
+    }
+
+    private func appendBrowsingEvent(_ event: BrowsingEvents) {
+        browsingEvents.append(event)
+    }
+
+    private func appendCameraStreamEvent(_ event: CameraStreamEvents) {
+        cameraStreamEvents.append(event)
+    }
+
+    /// Browsing 이벤트 수집 (타임아웃 지원)
+    func collectBrowsingEvents(count: Int, timeout: TimeInterval) async -> [BrowsingEvents] {
+        let deadline = Date().addingTimeInterval(timeout)
+        while browsingEvents.count < count && Date() < deadline {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        return browsingEvents
+    }
+
+    /// CameraStream 이벤트 수집 (타임아웃 지원)
+    func collectCameraStreamEvents(count: Int, timeout: TimeInterval) async -> [CameraStreamEvents] {
+        let deadline = Date().addingTimeInterval(timeout)
+        while cameraStreamEvents.count < count && Date() < deadline {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        return cameraStreamEvents
+    }
+
+    /// 수집된 이벤트 초기화
+    func reset() {
+        browsingEvents.removeAll()
+        cameraStreamEvents.removeAll()
+    }
+}


### PR DESCRIPTION
## 🔗 연관된 이슈
- closed #288

## 📌 요약
Browser 리팩터링 전 동등성 검증을 위한 테스트 코드를 작성했습니다.

## 🔍 상세

### Browser Test Suite (Swift Testing 사용)
총 **11개의 테스트 시나리오**로 Browser의 핵심 기능을 검증합니다.

#### 기기 검색
- 주변 기기 발견 시 `deviceFound` 이벤트 발생
- 기기 사라짐 시 `deviceLost` 이벤트 발생
- `deviceType` 없는 기기 필터링

#### 카메라 스트림
- `capturePhoto()` 호출 시 `captureCommand` 이벤트 발생

#### 명령 전송 안전성
- nil 세션일 때 `sendCommand` 크래시 방지
- nil 세션일 때 `sendRemoteCommand` 크래시 방지
- nil 세션일 때 `sendStreamData` 크래시 방지

#### 명령 수신
- `heartBeat` 명령 수신 시 정상 처리
- 알 수 없는 명령 수신 시 크래시 방지

#### Heartbeat
- `mirroringHeartbeat` 타임아웃 시 이벤트 발생
- Heartbeat 타임아웃 시 모든 스트림(browsing/connectionCheck/cameraPreview)에 이벤트 전달

### 테스트 헬퍼
- `EventCollector`: Browsing/CameraStream 이벤트 수집
- `HeartbeatEventCollector`: Heartbeat 이벤트 수집

AsyncStream 이벤트를 배열로 수집하여 검증할 수 있도록 구현했습니다.

<img width="549" height="312" alt="image" src="https://github.com/user-attachments/assets/f5b9ddc8-f370-4a13-9f7b-cff8ddc7697b" />

## 👀 리뷰 노트
Browser 분리 작업이 내용이 상당히 커 PR이 커질 것 같아 우선적으로 테스트 코드만 분리해서 PR 먼저 올렸습니다! 👀