### PR TITLE
[fix/#305] Watch 앱 상태 푸시 실패시 재시도한다.

### DIFF
--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/WatchConnectionManager+iOS.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/WatchConnectionManager+iOS.swift
@@ -12,6 +12,7 @@ import WatchConnectivity
 
 final class WatchConnectionManager: NSObject {
     private enum ActionValue: String {
+        case pushState
         case capture
         case connect
         case prepare
@@ -198,6 +199,12 @@ extension WatchConnectionManager: WCSessionDelegate {
         if let error: Error = error {
             self.logger.error("WCSession 활성화 실패: 오류=\(error.localizedDescription)")
         } else {
+            session.sendMessage(
+                [MessageKey.action.rawValue: ActionValue.pushState.rawValue],
+                replyHandler: nil
+            ) { error in
+                self.logger.warning("WCSession handshake 실패: \(error)")
+            }
             self.logger.info("WCSession 활성화 성공")
         }
     }

--- a/mirroringBooth/mirroringBooth/Device/Remote/AppleWatch/WatchConnectionManger+watchOS.swift
+++ b/mirroringBooth/mirroringBooth/Device/Remote/AppleWatch/WatchConnectionManger+watchOS.swift
@@ -102,7 +102,7 @@ final class WatchConnectionManager: NSObject {
     }
 
     /// iPhone에게 Watch 앱 상태를 전달합니다.
-    private func pushWatchAppState(_ state: AppStateValue) {
+    private func pushWatchAppState(_ state: AppStateValue, retryCount: Int = 0) {
         guard let session = self.session else {
             self.logger.error("WCSession이 지원되지 않아 상태를 푸시할 수 없습니다.")
             return
@@ -112,7 +112,16 @@ final class WatchConnectionManager: NSObject {
             try session.updateApplicationContext([MessageKey.appState.rawValue: state.rawValue])
             self.logger.info("Watch 앱 상태 푸시: \(state.rawValue)")
         } catch {
-            self.logger.error("Watch 앱 상태 푸시 실패: \(error.localizedDescription)")
+            self.logger.error("실패: \(error.localizedDescription) (시도: \(retryCount + 1))")
+            // 최대 3번까지만 재시도
+            if retryCount < 3 {
+                let nextRetry = retryCount + 1
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
+                    self?.pushWatchAppState(state, retryCount: nextRetry)
+                }
+            } else {
+                self.logger.error("최대 재시도 횟수 초과. 포기합니다.")
+            }
         }
     }
 

--- a/mirroringBooth/mirroringBooth/Device/Remote/AppleWatch/WatchConnectionManger+watchOS.swift
+++ b/mirroringBooth/mirroringBooth/Device/Remote/AppleWatch/WatchConnectionManger+watchOS.swift
@@ -12,6 +12,7 @@ import WatchConnectivity
 
 final class WatchConnectionManager: NSObject {
     private enum ActionValue: String {
+        case pushState
         case capture
         case connect
         case prepare
@@ -36,6 +37,7 @@ final class WatchConnectionManager: NSObject {
     private let session: WCSession?
     private let logger = Logger.watchConnectionManager
     private var lastAppState: AppStateValue = .terminated
+    private var watchState: AppStateValue = .inactive
 
     var onReachableChanged: ((Bool) -> Void)?
 
@@ -102,7 +104,7 @@ final class WatchConnectionManager: NSObject {
     }
 
     /// iPhone에게 Watch 앱 상태를 전달합니다.
-    private func pushWatchAppState(_ state: AppStateValue, retryCount: Int = 0) {
+    private func pushWatchAppState(_ state: AppStateValue) {
         guard let session = self.session else {
             self.logger.error("WCSession이 지원되지 않아 상태를 푸시할 수 없습니다.")
             return
@@ -112,16 +114,8 @@ final class WatchConnectionManager: NSObject {
             try session.updateApplicationContext([MessageKey.appState.rawValue: state.rawValue])
             self.logger.info("Watch 앱 상태 푸시: \(state.rawValue)")
         } catch {
-            self.logger.error("실패: \(error.localizedDescription) (시도: \(retryCount + 1))")
-            // 최대 3번까지만 재시도
-            if retryCount < 3 {
-                let nextRetry = retryCount + 1
-                DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) { [weak self] in
-                    self?.pushWatchAppState(state, retryCount: nextRetry)
-                }
-            } else {
-                self.logger.error("최대 재시도 횟수 초과. 포기합니다.")
-            }
+            self.logger.error("실패: \(error.localizedDescription)")
+            self.watchState = state
         }
     }
 
@@ -244,6 +238,11 @@ extension WatchConnectionManager: WCSessionDelegate {
             self.logger.info("모든 촬영 완료 수신됨.")
             Task { @MainActor in
                 self.onReceiveCaptureComplete?()
+            }
+        } else if actionValue == ActionValue.pushState.rawValue {
+            self.logger.info("상태 푸시 명령 수신됨.")
+            Task { @MainActor in
+                self.pushWatchAppState(watchState)
             }
         }
     }


### PR DESCRIPTION
## 🔗 연관된 이슈
- closed #305 

## 📝 작업 내용

### 📌 요약
- watch 앱 상태 푸시 실패시 재시도 로직을 넣었습니다. (각 1초 후 최대 3회)
- (수정) 위 방식을 포기하고 아이폰에서 WCSession을 초기화할 때 상태를 푸시하라는 명령을 보내는 방식으로 수정

## 💬 리뷰 노트
- 로그가 잘 되어있어서 편했네요. 로그 굿
- (수정) 재시도 로직은 재시도 시간이 지나서 아이폰 앱이 켜지면 작동을 안 해서 방식을 변경했습니다. 

## 📸 영상 / 이미지 (Optional)
