### PR TITLE
[Fix/#308] CameraPreview 표시 중 Heartbeat 중복 처리를 방지한다.

### DIFF
--- a/mirroringBooth/mirroringBooth/Device/Camera/ConnectionCheck/ConnectionCheckView.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/ConnectionCheck/ConnectionCheckView.swift
@@ -99,6 +99,8 @@ struct ConnectionCheckView: View {
             store.send(.entry)
         }
         .onChange(of: store.state.isMirroringDisconnected) {
+            guard !store.state.showPreview else { return }
+
             store.browser.disconnect(useType: .mirroring)
             router.pop()
         }


### PR DESCRIPTION
## 🔗 연관된 이슈
- closed #308 

## 📝 작업 내용

### 📌 요약
CameraPreview의 알럿과 ConnectionCheckView의 pop이 동시에 동작하면서 알럿이 중복으로 출력되며 `샤샤샥` 사라지는 버그를 해결했습니다.

### 🔍 상세

문제 상황 재현을 위해 아래와 같이 `시나리오`를 산정했습니다.

```text
# 사용자 시나리오
BrowsingView -> ConnectionCheckView -> CameraPreview (ConnectionCheckView의 fullScreenCover)
```
1. 사용자는 `촬영기기(iPhone)`에서 미러링 기기를 연결하거나 미러링/리모트 기기를 연결한 후 `ConnectionCheckView`로 이동합니다.  
2. 사용자는 하단 "촬영 준비하기" 버튼을 눌러 `CameraPreview`를 `fullScreenCover`로 띄웁니다.  
3. 그 상태에서 사용자는 미러링기기의 `연결`을 끊습니다.

- ✅ 이때 기대 동작은 `CameraPreview`에서 "연결이 끊어졌습니다." 알럿과 함께 홈으로 이동해야합니다.
- ❌ 하지만, 알럿이 잠깐 보였다가 (샤샤샥 하고) BrowsingView로 이동된 뒤 알럿이 다시 발생되며 상태가 꼬이고 있었습니다.

핵심 문제는 `CameraPreview`를 `fullScreenCover`로 띄우면 ConnectionCheckView는 `dismiss`되지 않고 그 아래에 살아있다는 점이었습니다.

그러다보니 `Heatbeat` 타임아웃 발생 시 브라우저의 모든 이벤트 스트림을 관리하는 `BrowserStreamManager`가 모든 하트비트 스트림에 `.heartbeatTimeout` 이벤트를 방출합니다.

이때, **ConnectionCheckStore**와 **CameraPreviewStore**가 `동시에 이벤트를 수신`해서 문제가 발생되고 있었습니다.

- 아래 Store들이 동시에 이벤트를 수신함으로써 발생되는 흐름
   - ConnectionCheckStore는 `isMirroringDisconnected`를 `true`로 변경하여 View에서 `router.pop()` 실행
   - CameraPreviewStores도 `isMirroringDisconnected`를 `true`로 변경하여 알럿 표시 후 `router.reset()` 실행

이렇게 동시에 이벤트를 수신해버리니  
`CamerePreview`의 알럿은 잠깐 보였다가 fullScreenCorver가 dismiss되면서 슈슈슉 사라집니다. 동시에  
`ConnectionCheckView`의 `router.pop`도 실행되어 BrowsingView로 돌아가버려 네비게이션의 충돌이 발생하고 있었습니다.

이를 해결하기 위해 간단히 `guard`문을 추가하여 `ConnectionCheckView`가 `CamerePreview`를 표시하고 있을 때는 `Heartbeat` 반응을 건너뛰도록 했습니다.

```swift
// ConnectionCheckView.swift
.onChange(of: store.state.isMirroringDisconnected) {
    guard !store.state.showPreview else { return } # ✅ 추가 된 내용~

    store.browser.disconnect(useType: .mirroring)
    router.pop()
}
```

## 📸 영상 / 이미지 (Optional)

### 개선 전

https://github.com/user-attachments/assets/101de444-5165-4da6-814e-81c4f6d3ae40

### 개선 후

https://github.com/user-attachments/assets/4077997a-82d8-4463-81d4-dc412bbf24c0
