### PR TITLE
[Fix/#305] 와치 session이 열렸을 때 상태 업데이트 로직 개선

### DIFF
--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/WatchConnectionManager+iOS.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/WatchConnectionManager+iOS.swift
@@ -68,9 +68,7 @@ final class WatchConnectionManager: NSObject {
             self.logger.info("WCSession이 이미 활성화되어 있습니다.")
 
             // 이미 활성화된 경우 현재 reachable 상태를 확인하여 콜백 호출
-            Task { @MainActor in
-                self.onReachableChanged?(session.isReachable)
-            }
+            handleWatchReachability(session: session)
             return
         }
 
@@ -200,6 +198,7 @@ extension WatchConnectionManager: WCSessionDelegate {
         } else {
             self.logger.info("WCSession 활성화 성공")
         }
+        handleWatchReachability(session: session)
     }
 
     nonisolated func session(

--- a/mirroringBooth/mirroringBooth/Device/Remote/AppleWatch/WatchConnectionManger+watchOS.swift
+++ b/mirroringBooth/mirroringBooth/Device/Remote/AppleWatch/WatchConnectionManger+watchOS.swift
@@ -69,11 +69,11 @@ final class WatchConnectionManager: NSObject {
 
         session.delegate = self
 
-        // iPhone에게 Watch 앱이 active 상태임을 전달
-        pushWatchAppState(.active)
-
         if session.activationState == .activated {
             self.logger.info("WCSession이 이미 활성화되어 있습니다.")
+            
+            // 이미 활성화된 경우 상태 푸시
+            pushWatchAppState(.active)
 
             // 이미 활성화된 경우에도 현재 상태를 확인하여 콜백 호출
             let context: [String: Any] = session.receivedApplicationContext
@@ -190,6 +190,9 @@ extension WatchConnectionManager: WCSessionDelegate {
             self.logger.error("WCSession 활성화 실패: 오류=\(error.localizedDescription)")
         } else {
             self.logger.info("WCSession 활성화 성공")
+            Task { @MainActor in
+                self.pushWatchAppState(.active)
+            }
         }
 
         let context: [String: Any] = session.receivedApplicationContext


### PR DESCRIPTION
## 🔗 연관된 이슈
- closed #305 

## 📝 작업 내용

### 📌 요약
- watch: 세션 개설이 완료되었을 때 activationDidCompleteWith에서 state push 함수 호출
- iOS: 세션 개설이 완료되었을 때 handleWatchReachability를 호출하여 상태 업데이트


## 📸 영상 / 이미지 (Optional)

https://github.com/user-attachments/assets/383e86e4-0063-4235-b4e3-604b59c8b237

