### PR TITLE
[#311] 촬영 후 워치에 완료뷰가 뜨지 않는 문제를 해결한다

### DIFF
--- a/mirroringBooth/mirroringBooth/Device/Camera/Streaming/CameraPreviewStore.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Streaming/CameraPreviewStore.swift
@@ -159,6 +159,7 @@ private extension CameraPreviewStore {
         cameraManager.onAllPhotosStored = { [weak self] in
             Task { @MainActor in
                 self?.browser.sendCommand(.onStoreAllPhotos)
+                self?.watchConnectionManager?.sendCaptureComplete()
                 self?.reduce(.captureCompleted)
                 self?.reduce(.setTransferCount(0))
             }


### PR DESCRIPTION
## 🔗 연관된 이슈
- closed #311


## 📝 작업 내용

### 📌 요약 && 🔍 상세
- sendCaptureComplete()를 호출했습니다
- ~~S022 찬양~~

<img width="588" height="556" alt="image" src="https://github.com/user-attachments/assets/4fe81fb8-9ccb-427e-af0b-df5b6d71589f" />

