### PR TITLE
[Refactor/#315] 와이파이 연결 없이 연결 개선

### DIFF
--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/Browser.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/Browser.swift
@@ -292,6 +292,12 @@ extension Browser: MCSessionDelegate {
             remoteHeartBeater?.start()
         }
 
+        if state == .connecting {
+            browsingManager.stopIfBrowsing()
+        } else if state == .notConnected || state == .connected {
+            browsingManager.startIfBrowsing()
+        }
+
         DispatchQueue.main.async {
             self.handleConnectionStateChange(newState, device: device, session: session, peerID: peerID)
         }

--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/Browser.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/Browser.swift
@@ -13,18 +13,12 @@ import OSLog
 /// 다른 기기를 탐색하고 연결하여 스트림 데이터(비디오/사진)를 전송
 final class Browser: NSObject, BrowserCommandDelegate {
 
-    enum SessionType: String {
-        case streaming
-        case command
-    }
-
     private let logger = Logger.browser
 
     private let serviceType: String
     private let peerID: MCPeerID
     private var mirroringSession: MCSession?
     var isMirroringSessionActive: Bool { mirroringSession?.connectedPeers.count == 1 }
-    private var mirroringCommandSession: MCSession?
     private var remoteSession: MCSession?
     var isRemoteSessionActive: Bool { remoteSession?.connectedPeers.count == 1 }
     let browsingManager: BrowsingManager
@@ -111,15 +105,8 @@ final class Browser: NSObject, BrowserCommandDelegate {
                 securityIdentity: nil,
                 encryptionPreference: .required
             )
-            self.mirroringCommandSession = MCSession(
-                peer: peerID,
-                securityIdentity: nil,
-                encryptionPreference: .none
-            )
             mirroringSession?.delegate = self
-            mirroringCommandSession?.delegate = self
-            // 커맨드 세션에 대해 먼저 연결을 요청합니다.
-            targetSession = mirroringCommandSession
+            targetSession = mirroringSession
         case .remote:
             targetRemoteDeviceID = deviceID
             self.remoteSession = MCSession(
@@ -135,7 +122,7 @@ final class Browser: NSObject, BrowserCommandDelegate {
         browsingManager.invitePeer(
             deviceID,
             to: targetSession,
-            withContext: SessionType.command.rawValue.data(using: .utf8),
+            withContext: nil,
             timeout: 10
         )
         logger.info("연결 요청 전송: \(deviceID) (\(useType == .mirroring ? "미러링" : "리모트"))")
@@ -157,8 +144,11 @@ final class Browser: NSObject, BrowserCommandDelegate {
             return
         }
 
+        var payload = Data([0x01])
+        payload.append(data)
+
         do {
-            try mirroringSession.send(data, toPeers: connectedPeers, with: .unreliable)
+            try mirroringSession.send(payload, toPeers: connectedPeers, with: .unreliable)
         } catch {
             logger.warning("스트림 데이터 전송 실패 : \(error.localizedDescription)")
         }
@@ -195,16 +185,19 @@ final class Browser: NSObject, BrowserCommandDelegate {
 
     /// 미러링 기기에게 명령을 전송합니다.
     func sendCommand(_ command: MirroringDeviceCommand) {
-        guard let mirroringCommandSession, let data = command.rawValue.data(using: .utf8) else { return }
-        let connectedPeers = mirroringCommandSession.connectedPeers
+        guard let mirroringSession, let commandData = command.rawValue.data(using: .utf8) else { return }
+        let connectedPeers = mirroringSession.connectedPeers
         guard !connectedPeers.isEmpty else {
-            logger.warning("명령 전송 실패: commandSession에 연결된 피어가 없습니다")
+            logger.warning("명령 전송 실패: mirroringSession에 연결된 피어가 없습니다")
             return
         }
 
+        var payload = Data([0x00])
+        payload.append(commandData)
+
         do {
-            try mirroringCommandSession.send(
-                data,
+            try mirroringSession.send(
+                payload,
                 toPeers: connectedPeers,
                 with: .reliable
             )
@@ -218,7 +211,7 @@ final class Browser: NSObject, BrowserCommandDelegate {
 
     /// 리모트 기기에게 명령을 전송합니다.
     func sendRemoteCommand(_ command: RemoteDeviceCommand) {
-        guard let data = command.rawValue.data(using: .utf8) else { return }
+        guard let commandData = command.rawValue.data(using: .utf8) else { return }
 
         guard let connectedPeers = remoteSession?.connectedPeers,
               !connectedPeers.isEmpty else {
@@ -226,9 +219,12 @@ final class Browser: NSObject, BrowserCommandDelegate {
             return
         }
 
+        var payload = Data([0x00])
+        payload.append(commandData)
+
         do {
             try remoteSession?.send(
-                data,
+                payload,
                 toPeers: connectedPeers,
                 with: .reliable
             )
@@ -253,9 +249,7 @@ final class Browser: NSObject, BrowserCommandDelegate {
         switch useType {
         case .mirroring:
             mirroringSession?.disconnect()
-            mirroringCommandSession?.disconnect()
             mirroringSession = nil
-            mirroringCommandSession = nil
             targetMirroringDeviceID = nil
             mirroringHeartBeater.stop()
             logger.info("미러링 연결 해제")
@@ -285,18 +279,6 @@ extension Browser: MCSessionDelegate {
 
         let newState = logAndConvertState(state, for: peerID.displayName, sessionType: sessionTypeLabel)
 
-        // 명령 세션이 연결되면 미러링 세션을 초대합니다.
-        if let mirroringSession, sessionTypeLabel == "미러링 명령", newState == .connected {
-            logger.info("미러링 커맨드 세션 연결 완료, 미러링 세션 초대 시작")
-            browsingManager.invitePeer(
-                peerID.displayName,
-                to: mirroringSession,
-                withContext: SessionType.streaming.rawValue.data(using: .utf8),
-                timeout: 10
-            )
-            return
-        }
-
         let deviceType = browsingManager.getPeer(for: peerID.displayName)?.type ?? .unknown
         let device = NearbyDevice(id: peerID.displayName, state: newState, type: deviceType)
 
@@ -318,7 +300,6 @@ extension Browser: MCSessionDelegate {
     private func getSessionTypeLabel(for session: MCSession) -> String {
         switch session {
         case mirroringSession: return "미러링"
-        case mirroringCommandSession: return "미러링 명령"
         case remoteSession: return "리모트"
         default: return "알 수 없음"
         }
@@ -352,11 +333,9 @@ extension Browser: MCSessionDelegate {
         peerID: MCPeerID
     ) {
         let isMirroringTarget = session === mirroringSession && peerID.displayName == targetMirroringDeviceID
-        let isMirroringCommandTarget = (session === mirroringCommandSession)
-        && (peerID.displayName == targetMirroringDeviceID)
         let isRemoteTarget = session === remoteSession && peerID.displayName == targetRemoteDeviceID
 
-        guard isMirroringTarget || isMirroringCommandTarget || isRemoteTarget else { return }
+        guard isMirroringTarget || isRemoteTarget else { return }
 
         switch state {
         case .connected:
@@ -364,7 +343,7 @@ extension Browser: MCSessionDelegate {
 
         case .notConnected:
             streamManager.yieldBrowsingEvent(.deviceConnectionFailed)
-            if isMirroringTarget || isMirroringCommandTarget {
+            if isMirroringTarget {
                 targetMirroringDeviceID = nil
             }
             if isRemoteTarget {
@@ -380,10 +359,15 @@ extension Browser: MCSessionDelegate {
         didReceive data: Data,
         fromPeer peerID: MCPeerID
     ) {
-        if session === mirroringCommandSession || session === remoteSession {
-            commandManager.execute(data: data)
-        } else if session === mirroringSession {
-            logger.info("스트림 세션에서 데이터 수신: \(data.count) bytes")
+        guard let firstByte = data.first else { return }
+        let payload = data.dropFirst()
+
+        if session === mirroringSession || session === remoteSession {
+            if firstByte == 0x00 {
+                commandManager.execute(data: payload)
+            } else if firstByte == 0x01 {
+                logger.info("스트림 세션에서 데이터 수신: \(payload.count) bytes")
+            }
         }
     }
 

--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/Browser.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/Browser.swift
@@ -148,7 +148,11 @@ final class Browser: NSObject, BrowserCommandDelegate {
         payload.append(data)
 
         do {
-            try mirroringSession.send(payload, toPeers: connectedPeers, with: .unreliable)
+            try mirroringSession.send(
+                payload,
+                toPeers: connectedPeers,
+                with: .unreliable
+            )
         } catch {
             logger.warning("스트림 데이터 전송 실패 : \(error.localizedDescription)")
         }

--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/Browser.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/Browser.swift
@@ -123,7 +123,7 @@ final class Browser: NSObject, BrowserCommandDelegate {
             deviceID,
             to: targetSession,
             withContext: nil,
-            timeout: 10
+            timeout: 20
         )
         logger.info("연결 요청 전송: \(deviceID) (\(useType == .mirroring ? "미러링" : "리모트"))")
     }

--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/Browser.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/Browser.swift
@@ -144,7 +144,7 @@ final class Browser: NSObject, BrowserCommandDelegate {
             return
         }
 
-        var payload = Data([0x01])
+        var payload = Data([MultipeerHeader.streaming.rawValue])
         payload.append(data)
 
         do {
@@ -192,7 +192,7 @@ final class Browser: NSObject, BrowserCommandDelegate {
             return
         }
 
-        var payload = Data([0x00])
+        var payload = Data([MultipeerHeader.command.rawValue])
         payload.append(commandData)
 
         do {
@@ -219,7 +219,7 @@ final class Browser: NSObject, BrowserCommandDelegate {
             return
         }
 
-        var payload = Data([0x00])
+        var payload = Data([MultipeerHeader.command.rawValue])
         payload.append(commandData)
 
         do {
@@ -363,9 +363,9 @@ extension Browser: MCSessionDelegate {
         let payload = data.dropFirst()
 
         if session === mirroringSession || session === remoteSession {
-            if firstByte == 0x00 {
+            if firstByte == MultipeerHeader.command.rawValue {
                 commandManager.execute(data: payload)
-            } else if firstByte == 0x01 {
+            } else if firstByte == MultipeerHeader.streaming.rawValue {
                 logger.info("스트림 세션에서 데이터 수신: \(payload.count) bytes")
             }
         }

--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/Browser.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/Browser.swift
@@ -375,8 +375,6 @@ extension Browser: MCSessionDelegate {
         if session === mirroringSession || session === remoteSession {
             if firstByte == MultipeerHeader.command.rawValue {
                 commandManager.execute(data: payload)
-            } else if firstByte == MultipeerHeader.streaming.rawValue {
-                logger.info("스트림 세션에서 데이터 수신: \(payload.count) bytes")
             }
         }
     }

--- a/mirroringBooth/mirroringBooth/Device/Camera/Browser/Manager/BrowsingManager.swift
+++ b/mirroringBooth/mirroringBooth/Device/Camera/Browser/Manager/BrowsingManager.swift
@@ -15,6 +15,7 @@ final class BrowsingManager: NSObject {
     private let browser: MCNearbyServiceBrowser
     private let peerID: MCPeerID
     private let streamManager: BrowserStreamManager
+    private var isBrowsing: Bool = false
 
     /// 발견된 Peer 목록
     private(set) var discoveredPeers: [String: (peer: MCPeerID, type: DeviceType)] = [:]
@@ -28,14 +29,26 @@ final class BrowsingManager: NSObject {
     }
 
     func startSearching() {
+        isBrowsing = true
         browser.stopBrowsingForPeers()
         browser.startBrowsingForPeers()
         logger.info("주변 기기를 검색합니다.")
     }
 
     func stopSearching() {
+        isBrowsing = false
         browser.stopBrowsingForPeers()
         logger.info("주변 기기 검색을 중지합니다.")
+    }
+
+    func startIfBrowsing() {
+        guard isBrowsing else { return }
+        browser.startBrowsingForPeers()
+    }
+
+    func stopIfBrowsing() {
+        guard isBrowsing else { return }
+        browser.stopBrowsingForPeers()
     }
 
     /// 특정 기기에게 연결 초대를 전송합니다.

--- a/mirroringBooth/mirroringBooth/Device/Common/MultipeerHeader.swift
+++ b/mirroringBooth/mirroringBooth/Device/Common/MultipeerHeader.swift
@@ -1,0 +1,11 @@
+//
+//  MultipeerHeader.swift
+//  mirroringBooth
+//
+//  Created by Liam on 3/2/26.
+//
+
+enum MultipeerHeader: UInt8 {
+    case command = 0x00
+    case streaming = 0x01
+}

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Advertiser.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Advertiser.swift
@@ -134,9 +134,9 @@ extension Advertiser: MCSessionDelegate {
         let payload = data.dropFirst()
 
         if session === self.session {
-            if firstByte == 0x00 {
+            if firstByte == MultipeerHeader.command.rawValue {
                 commandManager.execute(data: payload, advertiserType: &advertiserType)
-            } else if firstByte == 0x01 {
+            } else if firstByte == MultipeerHeader.streaming.rawValue {
                 streamManager.yieldVideo(payload)
             }
         }

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Advertiser.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Advertiser.swift
@@ -127,6 +127,11 @@ extension Advertiser: MCSessionDelegate {
             heartBeater.start()
             streamManager.yieldAdvertising(.onConnected)
         }
+        if state == .connecting {
+            connectionManager.stopIfAdvertising()
+        } else if state == .notConnected || state == .connected {
+            connectionManager.startIfAdvertising()
+        }
     }
 
     func session(_ session: MCSession, didReceive data: Data, fromPeer peerID: MCPeerID) {

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Advertiser.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Advertiser.swift
@@ -17,7 +17,6 @@ final class Advertiser: NSObject {
     private let serviceType: String
     private let peerID: MCPeerID
     private var session: MCSession?
-    private var commandSession: MCSession?
     private let photoCacheManager: PhotoCacheManager
     private let heartBeater: HeartBeater
     var advertiserType: DeviceUseType = .mirroring // heartbeat 메시지 종류 구분을 위해 추가
@@ -82,7 +81,7 @@ final class Advertiser: NSObject {
 
         connectionManager.delegate = self
         connectionManager.connectedPeersCheck = { [weak self] peerID in
-            self?.commandSession?.connectedPeers.contains(peerID) == true
+            self?.session?.connectedPeers.contains(peerID) == true
         }
         heartBeater.delegate = self
     }
@@ -104,9 +103,7 @@ final class Advertiser: NSObject {
     /// 세션과 연결을 해제합니다.
     func disconnect() {
         session?.disconnect()
-        commandSession?.disconnect()
         session = nil
-        commandSession = nil
         heartBeater.stop()
         logger.info("연결 해제: \(self.peerID.displayName)")
     }
@@ -118,7 +115,7 @@ final class Advertiser: NSObject {
 
     /// 연결된 카메라 기기(iPhone)에게 명령을 전송합니다.
     func sendCommand(_ command: CameraDeviceCommand) {
-        commandManager.send(command, session: commandSession)
+        commandManager.send(command, session: session)
     }
 }
 
@@ -128,19 +125,20 @@ extension Advertiser: MCSessionDelegate {
     func session(_ session: MCSession, peer peerID: MCPeerID, didChange state: MCSessionState) {
         if session === self.session, state == .connected {
             heartBeater.start()
-        }
-        if session === self.commandSession, state == .connected {
             streamManager.yieldAdvertising(.onConnected)
         }
     }
 
     func session(_ session: MCSession, didReceive data: Data, fromPeer peerID: MCPeerID) {
+        guard let firstByte = data.first else { return }
+        let payload = data.dropFirst()
+
         if session === self.session {
-            // 스트림 세션에서 수신
-            streamManager.yieldVideo(data)
-        } else if session === commandSession {
-            // 명령 세션에서 수신
-            commandManager.execute(data: data, advertiserType: &advertiserType)
+            if firstByte == 0x00 {
+                commandManager.execute(data: payload, advertiserType: &advertiserType)
+            } else if firstByte == 0x01 {
+                streamManager.yieldVideo(payload)
+            }
         }
     }
 
@@ -193,13 +191,8 @@ extension Advertiser: MCSessionDelegate {
 
 // MARK: - ConnectionManager Delegate
 extension Advertiser: ConnectionManagerDelegate {
-    func connectionManager(_ manager: AdvertisingManager, didCreateSession session: MCSession, type: String) {
-        if type == "streaming" {
-            self.session = session
-            session.delegate = self
-        } else if type == "command" {
-            self.commandSession = session
-            session.delegate = self
-        }
+    func connectionManager(_ manager: AdvertisingManager, didCreateSession session: MCSession) {
+        self.session = session
+        session.delegate = self
     }
 }

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Manager/AdvertiserCommandManager.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Manager/AdvertiserCommandManager.swift
@@ -81,12 +81,15 @@ final class AdvertiserCommandManager {
         guard let session, let commandData = command.rawValue.data(using: .utf8) else { return }
         let connectedPeers = session.connectedPeers
         guard !connectedPeers.isEmpty else {
-            Logger.advertiserCommandmanager.warning("명령 전송 실패: commandSession에 연결된 피어가 없습니다")
+            Logger.advertiserCommandmanager.warning("명령 전송 실패: 연결된 피어가 없습니다")
             return
         }
 
+        var payload = Data([0x00])
+        payload.append(commandData)
+
         do {
-            try session.send(commandData, toPeers: connectedPeers, with: .reliable)
+            try session.send(payload, toPeers: connectedPeers, with: .reliable)
             if command != .heartBeat {
                 Logger.advertiserCommandmanager.info("촬영 명령 전송: \(command.rawValue)")
             }

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Manager/AdvertiserCommandManager.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Manager/AdvertiserCommandManager.swift
@@ -85,7 +85,7 @@ final class AdvertiserCommandManager {
             return
         }
 
-        var payload = Data([0x00])
+        var payload = Data([MultipeerHeader.command.rawValue])
         payload.append(commandData)
 
         do {

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Manager/AdvertisingManager.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Manager/AdvertisingManager.swift
@@ -10,7 +10,7 @@ import MultipeerConnectivity
 import OSLog
 
 protocol ConnectionManagerDelegate: AnyObject {
-    func connectionManager(_ manager: AdvertisingManager, didCreateSession session: MCSession, type: String)
+    func connectionManager(_ manager: AdvertisingManager, didCreateSession session: MCSession)
 }
 
 final class AdvertisingManager: NSObject {
@@ -51,41 +51,22 @@ extension AdvertisingManager: MCNearbyServiceAdvertiserDelegate {
                     didReceiveInvitationFromPeer peerID: MCPeerID,
                     withContext context: Data?,
                     invitationHandler: @escaping (Bool, MCSession?) -> Void) {
-        guard let context,
-              let type = String(data: context, encoding: .utf8) else {
-            Logger.advertisingManager.warning("초대 수신 실패: context 파싱 불가 - \(peerID.displayName)")
-            invitationHandler(false, nil)
-            return
-        }
-
         // 이미 연결된 피어인지 확인
         let isAlreadyConnected = connectedPeersCheck?(peerID) ?? false
         guard isBlockingInvitation == false || isAlreadyConnected else {
             invitationHandler(false, nil)
             return
         }
-        Logger.advertisingManager.info("초대 수신: \(peerID.displayName)(타입: \(type))")
+        Logger.advertisingManager.info("초대 수신: \(peerID.displayName)")
 
         // 세션 생성
-        let session: MCSession
-        if type == "streaming" {
-            session = MCSession(
-                peer: advertiser.myPeerID,
-                securityIdentity: nil,
-                encryptionPreference: .required
-            )
-        } else if type == "command" {
-            session = MCSession(
-                peer: advertiser.myPeerID,
-                securityIdentity: nil,
-                encryptionPreference: .none
-            )
-        } else {
-            invitationHandler(false, nil)
-            return
-        }
+        let session = MCSession(
+            peer: advertiser.myPeerID,
+            securityIdentity: nil,
+            encryptionPreference: .required
+        )
         // 델리게이트에게 알림 (Advertiser가 세션을 저장하고 Delegate를 설정하도록)
-        delegate?.connectionManager(self, didCreateSession: session, type: type)
+        delegate?.connectionManager(self, didCreateSession: session)
         invitationHandler(true, session)
     }
 }

--- a/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Manager/AdvertisingManager.swift
+++ b/mirroringBooth/mirroringBooth/Device/SubDevice/Advertiser/Manager/AdvertisingManager.swift
@@ -16,6 +16,7 @@ protocol ConnectionManagerDelegate: AnyObject {
 final class AdvertisingManager: NSObject {
     private let advertiser: MCNearbyServiceAdvertiser
     private var isBlockingInvitation: Bool = false
+    private var isAdvertising: Bool = false
 
     weak var delegate: ConnectionManagerDelegate?
     var connectedPeersCheck: ((MCPeerID) -> Bool)? // 특정 피어가 이미 연결되어 있는지 확인하는 클로저
@@ -32,6 +33,7 @@ final class AdvertisingManager: NSObject {
 
     func startAdvertising() {
         isBlockingInvitation = false
+        isAdvertising = true
         advertiser.startAdvertisingPeer()
         Logger.advertisingManager.info("광고를 시작합니다.")
     }
@@ -41,8 +43,21 @@ final class AdvertisingManager: NSObject {
             isBlockingInvitation = true
             return
         }
+        isAdvertising = false
         advertiser.stopAdvertisingPeer()
         Logger.advertisingManager.info("광고를 중단합니다.")
+    }
+
+    func startIfAdvertising() {
+        if isAdvertising {
+            advertiser.startAdvertisingPeer( )
+        }
+    }
+
+    func stopIfAdvertising() {
+        if isAdvertising {
+            advertiser.stopAdvertisingPeer( )
+        }
     }
 }
 
@@ -58,6 +73,8 @@ extension AdvertisingManager: MCNearbyServiceAdvertiserDelegate {
             return
         }
         Logger.advertisingManager.info("초대 수신: \(peerID.displayName)")
+
+        advertiser.stopAdvertisingPeer()
 
         // 세션 생성
         let session = MCSession(

--- a/mirroringBooth/mirroringBoothTests/AdvertiserTests.swift
+++ b/mirroringBooth/mirroringBoothTests/AdvertiserTests.swift
@@ -49,7 +49,9 @@ final class AdvertiserTests: XCTestCase {
         defer { streamTask.cancel() }
 
         // WHEN
-        await advertiser.session(session, didReceive: testData, fromPeer: peerID)
+        var payload = Data([MultipeerHeader.streaming.rawValue])
+        payload.append(testData)
+        await advertiser.session(session, didReceive: payload, fromPeer: peerID)
 
         // THEN
         await fulfillment(of: [expectation], timeout: 1.0)
@@ -61,7 +63,7 @@ final class AdvertiserTests: XCTestCase {
         // GIVEN
         let expectation = expectation(description: "연결 성공 이벤트 대기")
         let peerID = MCPeerID(displayName: "CommandPeer")
-        let session = try setupCommandSession(with: peerID)
+        let session = try setupSession(with: peerID)
 
         let streamTask = Task {
             for await event in await advertiser.advertisingStream {
@@ -86,7 +88,7 @@ final class AdvertiserTests: XCTestCase {
         let expectationWithoutRemote = expectation(description: "원격 미포함 모드 선택 명령 대기")
 
         let peerID = MCPeerID(displayName: "CommandPeer")
-        let session = try setupCommandSession(with: peerID)
+        let session = try setupSession(with: peerID)
 
         let streamTask = Task {
             for await event in await advertiser.advertisingStream {
@@ -105,11 +107,13 @@ final class AdvertiserTests: XCTestCase {
 
 
         // WHEN: 원격 포함 명령 수신
-        let commandWithRemote = MirroringDeviceCommand.navigateToSelectModeWithRemote.rawValue.data(using: .utf8)!
+        var commandWithRemote = Data([MultipeerHeader.command.rawValue])
+        commandWithRemote.append(MirroringDeviceCommand.navigateToSelectModeWithRemote.rawValue.data(using: .utf8)!)
         await advertiser.session(session, didReceive: commandWithRemote, fromPeer: peerID)
 
         // WHEN: 원격 미포함 명령 수신
-        let commandWithoutRemote = MirroringDeviceCommand.navigateToSelectModeWithoutRemote.rawValue.data(using: .utf8)!
+        var commandWithoutRemote = Data([MultipeerHeader.command.rawValue])
+        commandWithoutRemote.append(MirroringDeviceCommand.navigateToSelectModeWithoutRemote.rawValue.data(using: .utf8)!)
         await advertiser.session(session, didReceive: commandWithoutRemote, fromPeer: peerID)
 
         // THEN
@@ -120,7 +124,7 @@ final class AdvertiserTests: XCTestCase {
         // GIVEN
         let expectation = expectation(description: "리모트 연결 명령 대기")
         let peerID = MCPeerID(displayName: "CommandPeer")
-        let session = try setupCommandSession(with: peerID)
+        let session = try setupSession(with: peerID)
 
         let streamTask = Task {
             for await event in await advertiser.advertisingStream {
@@ -133,7 +137,8 @@ final class AdvertiserTests: XCTestCase {
 
 
         // WHEN
-        let command = RemoteDeviceCommand.navigateToRemoteConnected.rawValue.data(using: .utf8)!
+        var command = Data([MultipeerHeader.command.rawValue])
+        command.append(RemoteDeviceCommand.navigateToRemoteConnected.rawValue.data(using: .utf8)!)
         await advertiser.session(session, didReceive: command, fromPeer: peerID)
 
         // THEN
@@ -146,7 +151,7 @@ final class AdvertiserTests: XCTestCase {
         // GIVEN
         let expectation = expectation(description: "모드 선택 뷰 전환 명령 대기")
         let peerID = MCPeerID(displayName: "CommandPeer")
-        let session = try setupCommandSession(with: peerID)
+        let session = try setupSession(with: peerID)
 
         let streamTask = Task {
             for await event in await advertiser.modeSelectionStream {
@@ -159,7 +164,8 @@ final class AdvertiserTests: XCTestCase {
 
 
         // WHEN
-        let command = MirroringDeviceCommand.switchSelectModeView.rawValue.data(using: .utf8)!
+        var command = Data([MultipeerHeader.command.rawValue])
+        command.append(MirroringDeviceCommand.switchSelectModeView.rawValue.data(using: .utf8)!)
         await advertiser.session(session, didReceive: command, fromPeer: peerID)
 
         // THEN
@@ -174,7 +180,7 @@ final class AdvertiserTests: XCTestCase {
         let expectationHome = expectation(description: "홈 화면 이동 명령 대기")
 
         let peerID = MCPeerID(displayName: "CommandPeer")
-        let session = try setupCommandSession(with: peerID)
+        let session = try setupSession(with: peerID)
 
         let streamTask = Task {
             for await event in await advertiser.remoteConnectedViewStream {
@@ -190,11 +196,13 @@ final class AdvertiserTests: XCTestCase {
 
 
         // WHEN: Capture 명령
-        let commandCapture = RemoteDeviceCommand.navigateToRemoteCapture.rawValue.data(using: .utf8)!
+        var commandCapture = Data([MultipeerHeader.command.rawValue])
+        commandCapture.append(RemoteDeviceCommand.navigateToRemoteCapture.rawValue.data(using: .utf8)!)
         await advertiser.session(session, didReceive: commandCapture, fromPeer: peerID)
 
         // WHEN: Home 명령
-        let commandHome = RemoteDeviceCommand.navigateToHome.rawValue.data(using: .utf8)!
+        var commandHome = Data([MultipeerHeader.command.rawValue])
+        commandHome.append(RemoteDeviceCommand.navigateToHome.rawValue.data(using: .utf8)!)
         await advertiser.session(session, didReceive: commandHome, fromPeer: peerID)
 
         // THEN
@@ -207,7 +215,7 @@ final class AdvertiserTests: XCTestCase {
         // GIVEN
         let expectation = expectation(description: "리모트 완료 명령 대기")
         let peerID = MCPeerID(displayName: "CommandPeer")
-        let session = try setupCommandSession(with: peerID)
+        let session = try setupSession(with: peerID)
 
         let streamTask = Task {
             for await event in await advertiser.remoteCaptureViewStream {
@@ -220,7 +228,8 @@ final class AdvertiserTests: XCTestCase {
 
 
         // WHEN
-        let command = RemoteDeviceCommand.navigateToRemoteComplete.rawValue.data(using: .utf8)!
+        var command = Data([MultipeerHeader.command.rawValue])
+        command.append(RemoteDeviceCommand.navigateToRemoteComplete.rawValue.data(using: .utf8)!)
         await advertiser.session(session, didReceive: command, fromPeer: peerID)
 
         // THEN
@@ -237,7 +246,7 @@ final class AdvertiserTests: XCTestCase {
         let expectationPhotoReceived = expectation(description: "사진 수신 완료 대기")
 
         let peerID = MCPeerID(displayName: "CommandPeer")
-        let session = try setupCommandSession(with: peerID)
+        let session = try setupSession(with: peerID)
 
         let streamTask = Task {
             for await event in await advertiser.streamingStoreStream {
@@ -253,13 +262,16 @@ final class AdvertiserTests: XCTestCase {
 
 
         // WHEN
-        let commandAllStored = MirroringDeviceCommand.onStoreAllPhotos.rawValue.data(using: .utf8)!
+        var commandAllStored = Data([MultipeerHeader.command.rawValue])
+        commandAllStored.append(MirroringDeviceCommand.onStoreAllPhotos.rawValue.data(using: .utf8)!)
         await advertiser.session(session, didReceive: commandAllStored, fromPeer: peerID)
 
-        let commandUpdateCount = MirroringDeviceCommand.onUpdateCaptureCount.rawValue.data(using: .utf8)!
+        var commandUpdateCount = Data([MultipeerHeader.command.rawValue])
+        commandUpdateCount.append(MirroringDeviceCommand.onUpdateCaptureCount.rawValue.data(using: .utf8)!)
         await advertiser.session(session, didReceive: commandUpdateCount, fromPeer: peerID)
 
-        let commandCaptureEffect = MirroringDeviceCommand.captureEffect.rawValue.data(using: .utf8)!
+        var commandCaptureEffect = Data([MultipeerHeader.command.rawValue])
+        commandCaptureEffect.append(MirroringDeviceCommand.captureEffect.rawValue.data(using: .utf8)!)
         await advertiser.session(session, didReceive: commandCaptureEffect, fromPeer: peerID)
 
         // 사진 수신 시뮬레이션 (didFinishReceivingResource)
@@ -335,7 +347,7 @@ final class AdvertiserTests: XCTestCase {
         return session
     }
 
-    private func setupCommandSession(with peerID: MCPeerID) throws -> MCSession {
+    private func setupSession(with peerID: MCPeerID) throws -> MCSession {
         let context = "command".data(using: .utf8)
         let dummyAdvertiser = MCNearbyServiceAdvertiser(
             peer: peerID,

--- a/mirroringBooth/mirroringBoothTests/BrowserTests.swift
+++ b/mirroringBooth/mirroringBoothTests/BrowserTests.swift
@@ -129,7 +129,7 @@ struct BrowserTests {
         // GIVEN
         let (browser, _) = makeSUT()
 
-        // WHEN - mirroringCommandSession이 nil인 상태
+        // WHEN - mirroringSession이 nil인 상태
         browser.sendCommand(.heartBeat)
 
         // THEN - 크래시하지 않으면 성공
@@ -193,7 +193,8 @@ struct BrowserTests {
         let mockSession = MCSession(peer: testPeerID, securityIdentity: nil, encryptionPreference: .none)
 
         // WHEN - heartBeat 명령 수신 (크래시 없이 처리되면 성공)
-        let commandData = Data("heartBeat".utf8)
+        var commandData = Data([0x00])
+        commandData.append(Data("heartBeat".utf8))
         browser.session(mockSession, didReceive: commandData, fromPeer: testPeerID)
 
         // THEN - 크래시 없이 처리되면 성공
@@ -207,7 +208,8 @@ struct BrowserTests {
         let mockSession = MCSession(peer: testPeerID, securityIdentity: nil, encryptionPreference: .none)
 
         // WHEN - 알 수 없는 명령 수신
-        let commandData = Data("unknownCommand".utf8)
+        var commandData = Data([0x00])
+        commandData.append(Data("unknownCommand".utf8))
         browser.session(mockSession, didReceive: commandData, fromPeer: testPeerID)
 
         // THEN - 크래시 없이 처리되면 성공


### PR DESCRIPTION
## 🔗 연관된 이슈
- closed #315 

## 📝 작업 내용

### 📌 요약
- command session, streaming session 통합
- Invite 과정 진입 시 browser, advertiser 일시 정지
- 위 수정을 반영하여 advertiser, browser에 대한 테스트 수정
- Invite 타임아웃 10초 -> 20초

### 🔍 상세

- 왜 바뀌어야 했는가?
멀티피어는 블루투스와 P2P 와이파이를 사용할 수 있음에도 와이파이 공유기에 연결되지 않은 상태에서는 연결이 원활하지 않았습니다. 와이파이가 연결되지 않은 상태에서도 로컬 네트워크를 사용해 앱을 사용할 수 있도록 개선하고자 했습니다.

- command session, streaming session 통합 과정
  - 최초에 분리했던 이유: 카메라로 촬영 중인 화면을 실시간으로 미러링하는 세션과, 앱 동작 흐름을 제어하는 세션을 분리하여 실시간 스트리밍 데이터의 전달 상태에 영향을 받지 않고 흐름 제어 명령을 전송하는 것을 기대하였습니다. 또한 두 세션의 암호화 수준을 다르게 설정할 수 있다는 장점이 존재합니다.
  - 세션 통합을 결정한 이유: 분리했던 의도와는 다르게, reliable, unreliable을 구분하는 것으로 어느정도 전송하는 데이터의 구분이 가능합니다. 반면 세션을 분리함으로써 Invite 과정의 시간이 2배가 되는 문제가 생깁니다.
  - 통합 방법 : 헤더
  Common/MultipeerHeader에서 확인할 수 있듯, 전송하는 데이터 앞에 0x00(커맨드) 또는 0x01(스트리밍)의 헤더를 붙여 데이터를 전송하는 방식으로 구분한 데이터를 하나의 세션을 통해 보내도록 수정했습니다.

- Invite 과정 진입 시 browser, advertiser 일시 정지
https://loud-peach-31c.notion.site/Wireshark-3104c58a09fa80bf826af45748474bc2?source=copy_link
위 링크는 Wireshark를 통해 와이파이 없이 연결을 시도할 때 오가는 패킷 관측을 포함한 연구 내용입니다. 주요 포인트는 다음과 같습니다.
  - Invite 과정은 P2P 와이파이를 통해 이루어진다.
  - 실패한 연결에서는 잦은 Retransmission이 관측된다.
위 연구에서 관측한 결과 중에서, 잦은 Retransmission이 관측되는 이유는 advertiser나 browser가 블루투스를 사용하고, Invite가 P2P 와이파이를 사용하며 네트워크 칩이라는 하드웨어를 나눠 사용, 네트워크 간섭 등이 발생하는 탓으로 예상했습니다.
따라서 browser는 connecting 상태가 되는 순간, advertiser는 invite를 받는 순간 검색을 종료하고, 실패나 성공으로 완료되었을 때 다시 작동하도록 수정하였습니다.

- Invite 타임아웃 10초->20초
테스트 중 타임아웃을 늘렸을 때 실제 연결 시간이 20초까지 걸리지 않더라도 안정적으로 연결이 되는 모습을 관측하여 적용하였습니다.

## 💬 리뷰 노트
- 테스트 환경은 맥북 시뮬레이터(와이파이 연결), 아이폰(와이파이 미연결)입니다. 코드 리뷰어님 혹시나 와이파이가 연결되지 않은 다른 환경에서 테스트가 가능하다면 부탁드립니다.
