### PR TITLE
[#317] Canvas에서 메인스레드가 아닌 스레드에서 이미지를 비동기적으로 가져오도록 개선한다

### DIFF
--- a/mirroringBooth/mirroringBooth/Device/Mirroring/PhotoComposition/Component/PhotoFramePreview.swift
+++ b/mirroringBooth/mirroringBooth/Device/Mirroring/PhotoComposition/Component/PhotoFramePreview.swift
@@ -10,14 +10,12 @@ import SwiftUI
 struct PhotoFramePreview: View {
     let information: PhotoInformation
     private let hasPreloadedPhotoImages: Bool
-    @State private var photoImages: [UIImage?]
-    @State private var cachedPhotoImages: [URL: UIImage]
+    @State private var photoImagesByURL: [URL: UIImage]
 
     init(information: PhotoInformation, photoImages: [UIImage?] = []) {
         self.information = information
         self.hasPreloadedPhotoImages = photoImages.isEmpty == false
-        _photoImages = State(initialValue: photoImages)
-        _cachedPhotoImages = State(
+        _photoImagesByURL = State(
             initialValue: Dictionary(
                 uniqueKeysWithValues: zip(information.photos, photoImages).compactMap { photo, photoImage in
                     guard let photoImage else { return nil }
@@ -30,6 +28,7 @@ struct PhotoFramePreview: View {
     var body: some View {
         GeometryReader { geometry in
             let size = geometry.size
+            let currentPhotoImages = information.photos.map { photoImagesByURL[$0.url] }
 
             Canvas { context, _ in
                 let canvas = CGRect(origin: .zero, size: size)
@@ -46,8 +45,8 @@ struct PhotoFramePreview: View {
                     context.drawLayer { layer in
                         layer.clip(to: Path(roundedRect: slot, cornerRadius: 5))
 
-                        if index < photoImages.count,
-                           let photo = photoImages[index] {
+                        if index < currentPhotoImages.count,
+                           let photo = currentPhotoImages[index] {
                             let target = aspectFillRect(for: photo.size, into: slot)
                             layer.draw(Image(uiImage: photo), in: target)
                         } else {
@@ -92,17 +91,12 @@ struct PhotoFramePreview: View {
 
     private func synchronizePhotoImages() async {
         let currentPhotos = information.photos
-        var updatedPhotoImages = currentPhotos.map { cachedPhotoImages[$0.url] }
-        photoImages = updatedPhotoImages
-
-        for (index, photo) in currentPhotos.enumerated() where updatedPhotoImages[index] == nil {
+        for photo in currentPhotos where photoImagesByURL[photo.url] == nil {
             let loadedPhotoImage = await PhotoImageLoader.loadImage(from: photo.url)
             guard Task.isCancelled == false else { return }
             guard let loadedPhotoImage else { continue }
 
-            cachedPhotoImages[photo.url] = loadedPhotoImage
-            updatedPhotoImages[index] = loadedPhotoImage
-            photoImages = updatedPhotoImages
+            photoImagesByURL[photo.url] = loadedPhotoImage
         }
     }
 

--- a/mirroringBooth/mirroringBooth/Device/Mirroring/PhotoComposition/Component/PhotoFramePreview.swift
+++ b/mirroringBooth/mirroringBooth/Device/Mirroring/PhotoComposition/Component/PhotoFramePreview.swift
@@ -9,6 +9,23 @@ import SwiftUI
 
 struct PhotoFramePreview: View {
     let information: PhotoInformation
+    private let hasPreloadedPhotoImages: Bool
+    @State private var photoImages: [UIImage?]
+    @State private var cachedPhotoImages: [URL: UIImage]
+
+    init(information: PhotoInformation, photoImages: [UIImage?] = []) {
+        self.information = information
+        self.hasPreloadedPhotoImages = photoImages.isEmpty == false
+        _photoImages = State(initialValue: photoImages)
+        _cachedPhotoImages = State(
+            initialValue: Dictionary(
+                uniqueKeysWithValues: zip(information.photos, photoImages).compactMap { photo, photoImage in
+                    guard let photoImage else { return nil }
+                    return (photo.url, photoImage)
+                }
+            )
+        )
+    }
 
     var body: some View {
         GeometryReader { geometry in
@@ -29,9 +46,8 @@ struct PhotoFramePreview: View {
                     context.drawLayer { layer in
                         layer.clip(to: Path(roundedRect: slot, cornerRadius: 5))
 
-                        if index < information.photos.count,
-                           let photoData = information.photos[index].imageData,
-                           let photo = UIImage(data: photoData) {
+                        if index < photoImages.count,
+                           let photo = photoImages[index] {
                             let target = aspectFillRect(for: photo.size, into: slot)
                             layer.draw(Image(uiImage: photo), in: target)
                         } else {
@@ -68,6 +84,26 @@ struct PhotoFramePreview: View {
             }
         }
         .aspectRatio(information.layout.previewAspect, contentMode: .fit)
+        .task(id: information.photos) {
+            guard !hasPreloadedPhotoImages else { return }
+            await synchronizePhotoImages()
+        }
+    }
+
+    private func synchronizePhotoImages() async {
+        let currentPhotos = information.photos
+        var updatedPhotoImages = currentPhotos.map { cachedPhotoImages[$0.url] }
+        photoImages = updatedPhotoImages
+
+        for (index, photo) in currentPhotos.enumerated() where updatedPhotoImages[index] == nil {
+            let loadedPhotoImage = await PhotoImageLoader.loadImage(from: photo.url)
+            guard Task.isCancelled == false else { return }
+            guard let loadedPhotoImage else { continue }
+
+            cachedPhotoImages[photo.url] = loadedPhotoImage
+            updatedPhotoImages[index] = loadedPhotoImage
+            photoImages = updatedPhotoImages
+        }
     }
 
     /// Cliping 될 때 크기에 맞게 잘 잘리도록 전처리

--- a/mirroringBooth/mirroringBooth/Device/Mirroring/PhotoComposition/Model/Photo.swift
+++ b/mirroringBooth/mirroringBooth/Device/Mirroring/PhotoComposition/Model/Photo.swift
@@ -13,10 +13,6 @@ struct Photo: Identifiable, Hashable {
     let url: URL
     var selectNumber: Int?
 
-    var imageData: Data? {
-        return try? Data(contentsOf: url)
-    }
-
     static func == (lhs: Photo, rhs: Photo) -> Bool {
         lhs.id == rhs.id
     }

--- a/mirroringBooth/mirroringBooth/Device/Mirroring/PhotoComposition/PhotoComposer.swift
+++ b/mirroringBooth/mirroringBooth/Device/Mirroring/PhotoComposition/PhotoComposer.swift
@@ -10,7 +10,10 @@ import SwiftUI
 struct PhotoComposer {
     static func render(with information: PhotoInformation) async -> UIImage? {
         let photoImages = await PhotoImageLoader.loadImages(from: information.photos)
-        return renderPreview(with: information, photoImages: photoImages)
+        //  CI의 Xcode 16.4는 Default Actor Isolation을 `nonisolated`이 기본 설정
+        //  Xcode 버전이 26.* 이라면 Default Actor Isolation을 `MainActor`이 기본 설정
+        //  CI와 로컬 환경의 버전이 달라 임시로 CI 환경에 맞는 형태로 코드를 작성하였음
+        return await renderPreview(with: information, photoImages: photoImages)
     }
 
     @MainActor

--- a/mirroringBooth/mirroringBooth/Device/Mirroring/PhotoComposition/PhotoComposer.swift
+++ b/mirroringBooth/mirroringBooth/Device/Mirroring/PhotoComposition/PhotoComposer.swift
@@ -8,14 +8,22 @@
 import SwiftUI
 
 struct PhotoComposer {
+    static func render(with information: PhotoInformation) async -> UIImage? {
+        let photoImages = await PhotoImageLoader.loadImages(from: information.photos)
+        return renderPreview(with: information, photoImages: photoImages)
+    }
+
     @MainActor
-    static func render(with information: PhotoInformation) -> UIImage? {
+    private static func renderPreview(with information: PhotoInformation, photoImages: [UIImage?]) -> UIImage? {
         // 출력 이미지 크기 결정 (예: 1080 x 1440 또는 레이아웃 비율에 맞춤)
         let targetWidth: CGFloat = 1080
         let targetHeight: CGFloat = targetWidth / information.layout.previewAspect
         let targetSize = CGSize(width: targetWidth, height: targetHeight)
 
-        let preview = PhotoFramePreview(information: information)
+        let preview = PhotoFramePreview(
+            information: information,
+            photoImages: photoImages
+        )
         .frame(width: targetSize.width, height: targetSize.height)
 
         let renderer = ImageRenderer(content: preview)

--- a/mirroringBooth/mirroringBooth/Device/Mirroring/PhotoComposition/PhotoImageLoader.swift
+++ b/mirroringBooth/mirroringBooth/Device/Mirroring/PhotoComposition/PhotoImageLoader.swift
@@ -1,0 +1,26 @@
+//
+//  PhotoImageLoader.swift
+//  mirroringBooth
+//
+//  Created by 최윤진 on 2026-03-09.
+//
+
+import UIKit
+
+enum PhotoImageLoader {
+    static func loadImages(from photos: [Photo]) async -> [UIImage?] {
+        var loadedPhotoImages = [UIImage?](repeating: nil, count: photos.count)
+
+        for (index, photo) in photos.enumerated() {
+            loadedPhotoImages[index] = await loadImage(from: photo.url)
+        }
+
+        return loadedPhotoImages
+    }
+
+    static func loadImage(from photoUrl: URL) async -> UIImage? {
+        await Task.detached(priority: .userInitiated) {
+            UIImage(contentsOfFile: photoUrl.path(percentEncoded: false))
+        }.value
+    }
+}

--- a/mirroringBooth/mirroringBooth/Device/Mirroring/PhotoComposition/PhotoImageLoader.swift
+++ b/mirroringBooth/mirroringBooth/Device/Mirroring/PhotoComposition/PhotoImageLoader.swift
@@ -11,8 +11,17 @@ enum PhotoImageLoader {
     static func loadImages(from photos: [Photo]) async -> [UIImage?] {
         var loadedPhotoImages = [UIImage?](repeating: nil, count: photos.count)
 
-        for (index, photo) in photos.enumerated() {
-            loadedPhotoImages[index] = await loadImage(from: photo.url)
+        await withTaskGroup(of: (Int, UIImage?).self) { taskGroup in
+            for (index, photo) in photos.enumerated() {
+                taskGroup.addTask {
+                    let loadedPhotoImage = await loadImage(from: photo.url)
+                    return (index, loadedPhotoImage)
+                }
+            }
+
+            for await (index, loadedPhotoImage) in taskGroup {
+                loadedPhotoImages[index] = loadedPhotoImage
+            }
         }
 
         return loadedPhotoImages

--- a/mirroringBooth/mirroringBooth/Device/Mirroring/PhotoResult/ResultView.swift
+++ b/mirroringBooth/mirroringBooth/Device/Mirroring/PhotoResult/ResultView.swift
@@ -150,7 +150,7 @@ struct ResultView: View {
         }
         .task {
             if let photoInformation = store.state.resultPhoto {
-                guard let image = PhotoComposer.render(with: photoInformation) else { return }
+                guard let image = await PhotoComposer.render(with: photoInformation) else { return }
                 store.send(.setRenderedImage(image: image))
             }
         }


### PR DESCRIPTION
- closed #317

## 📝 작업 내용

### 📌 요약
- `Photo`가 직접 이미지 데이터를 읽지 않도록 정리하고, 이미지 로딩 책임을 `PhotoImageLoader`로 일원화했습니다.
- `PhotoFramePreview`가 필요한 이미지를 비동기로 불러오도록 개선했습니다.
- `PhotoComposer.render`를 비동기 처리로 전환해 렌더링 전에 이미지를 미리 로드하고, 결과 화면에서도 해당 흐름을 반영했습니다.

### 🔍 상세
- `Photo.imageData` 계산 프로퍼티를 제거해 모델이 파일 I/O를 직접 수행하지 않도록 수정했습니다.
- `PhotoImageLoader`를 추가해 단일 이미지와 다중 이미지 로딩을 한 곳에서 처리하도록 구성했습니다.
- `PhotoFramePreview`는 `[URL: UIImage]` 상태를 사용해 이미 로드된 이미지를 재사용하고, 없는 이미지만 `.task`에서 비동기로 불러오도록 변경했습니다.
- `PhotoComposer`는 합성 렌더링 전에 필요한 이미지를 먼저 로드한 뒤 `PhotoFramePreview`에 전달하도록 수정했습니다.
- `ResultView`는 렌더링 결과 생성 시 `await PhotoComposer.render(with:)`를 호출하도록 변경했습니다.

## 💬 리뷰 노트
### Instruments 시도
- Instruments를 사용하여 확실하게 메인스레드가 아닌 곳에서 로드하는 것을 확인하려고 시도했습니다
> 아래 두 이미지는 10장의 이미지를 받아온 후, 6장의 이미지를 선택하는 것을 녹화(?) 한 결과입니다
> 오히려 개선 쪽에서는 백그라운드 스레드에서의 동작이 미미한 형태로 나왔습니다
> 기존 쪽에서 백그라운드에서 동작하는 활동을 확인했지만, 이미지 로드는 아니었던거로 확인했습니다
<table>
<tr>
<td>
<img width="400" alt="테스트_동기" src="https://github.com/user-attachments/assets/a671f3fc-a926-44a1-b912-4e36b80b690b" />
<td>
<img width="400" alt="테스트_비동기" src="https://github.com/user-attachments/assets/ce99c2cc-66c6-4703-a7e9-dace6fd84b9b" />
</tr>
<tr>
<td align="center">기존
<td align="center">개선
</tr>
</table>

- 하지만 SwiftUI 앱이라 그런지 PhotoImageLoader.loadImage(from: ) 메서드를 찾아낼 수가 없었습니다

### print문으로 메인 스레드에서 동작하는지 확인
- `Thread.isMainThread` 를 통해 해당 코드가 메인스레드에서 동작하는지를 확인했습니다
- 결과는 모두 false로 출력되었으나 instruments로 안찍히는게 찜찜하게 남았습니다

https://github.com/user-attachments/assets/130278f7-323d-4062-9126-4e74e2c6dc21

## 📸 영상 / 이미지 (Optional)
### 정상 작동 확인 및 메모리 사용량 확인
- [기존 리팩토링 문서](https://github.com/boostcampwm2025/iOS03-dolAwang/wiki/Canvas에-비동기로-이미지-로드하기)와 비교했을때, 선택한 이미지가 플레이스홀더로만 남아있던 문제가 해결되었습니다.

<table>
<tr>
<td> <video src=https://github.com/user-attachments/assets/09acfcf3-d4ba-4be4-93f3-202f01c9b571>
<td> <video src=https://github.com/user-attachments/assets/05e35196-b657-4f8b-9f13-937a9158acbd>
<tr>
<tr>
<td align="center"> 정상 액션 확인
<td align="center"> 메모리 사용량
</tr>
</table>